### PR TITLE
[HOTSPOT-176] 가족 구성원 추가 승인/반려 알림 발행 OutBox 패턴 구현

### DIFF
--- a/src/main/java/hotspot/admin/common/exception/ApplicationException.java
+++ b/src/main/java/hotspot/admin/common/exception/ApplicationException.java
@@ -7,4 +7,8 @@ public class ApplicationException extends BaseException {
     public ApplicationException(BaseErrorCode code) {
         super(code);
     }
+
+    public ApplicationException(BaseErrorCode code, Throwable cause) {
+        super(code, cause);
+    }
 }

--- a/src/main/java/hotspot/admin/common/exception/BaseException.java
+++ b/src/main/java/hotspot/admin/common/exception/BaseException.java
@@ -13,6 +13,11 @@ public abstract class BaseException extends RuntimeException {
         this.code = code;
     }
 
+    protected BaseException(BaseErrorCode code, Throwable cause) {
+        super(code.getMessage(), cause);
+        this.code = code;
+    }
+
     public static <T extends BaseException> T from(BaseErrorCode code, Class<T> exceptionClass) {
         try {
             return exceptionClass.getConstructor(BaseErrorCode.class).newInstance(code);

--- a/src/main/java/hotspot/admin/common/exception/code/OutboxErrorCode.java
+++ b/src/main/java/hotspot/admin/common/exception/code/OutboxErrorCode.java
@@ -1,0 +1,20 @@
+package hotspot.admin.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OutboxErrorCode implements BaseErrorCode {
+    OUTBOX_EVENT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OUTBOX_001", "Outbox 이벤트 저장에 실패했습니다."),
+    OUTBOX_PAYLOAD_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OUTBOX_002", "Outbox payload 직렬화에 실패했습니다."),
+    OUTBOX_EVENT_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OUTBOX_003", "Outbox 이벤트 발행에 실패했습니다."),
+    FAMILY_REQUEST_EVENT_BUILD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OUTBOX_004", "가족 요청 이벤트 생성에 실패했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyJpaRepository.java
+++ b/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyJpaRepository.java
@@ -12,7 +12,7 @@ import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.infrastructure.entity.FamilyApplyEntity;
 
 public interface FamilyApplyJpaRepository extends JpaRepository<FamilyApplyEntity, Long> {
-    /** 요청 ID/유형/현재 상태가 일치할 때만 상태를 갱신한다. */
+    /** 대기중 가족 요청만 목표 상태(승인/반려)로 조건부 업데이트한다. */
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
             value = """
@@ -37,4 +37,18 @@ public interface FamilyApplyJpaRepository extends JpaRepository<FamilyApplyEntit
 
     /** 요청 ID와 요청 유형으로 요청 엔티티를 조회한다. */
     Optional<FamilyApplyEntity> findByFamilyApplyIdAndApplyType(Long familyApplyId, ApplyType applyType);
+
+    /** 요청 ID와 요청 유형으로 대상 이름을 조회한다. */
+    @Query("""
+            SELECT m.name
+            FROM FamilyApplyEntity fa
+            JOIN fa.targetSubscription s
+            JOIN s.member m
+            WHERE fa.familyApplyId = :familyApplyId
+              AND fa.applyType = :applyType
+            """)
+    Optional<String> findTargetNameByFamilyApplyIdAndApplyType(
+            @Param("familyApplyId") Long familyApplyId,
+            @Param("applyType") ApplyType applyType
+    );
 }

--- a/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyRepositoryImpl.java
+++ b/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import hotspot.admin.family.domain.ApplyType;
+import hotspot.admin.family.domain.FamilyApply;
 import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.infrastructure.entity.FamilyApplyEntity;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
@@ -17,7 +18,7 @@ public class FamilyApplyRepositoryImpl implements FamilyApplyRepository {
 
     private final FamilyApplyJpaRepository familyApplyJpaRepository;
 
-    /** 대기중 요청을 목표 상태(승인/반려)로 조건부 업데이트한다. */
+    /** 대기중 가족 요청만 목표 상태(승인/반려)로 조건부 업데이트한다. */
     @Override
     public int updateFamilyRequestStatus(
             Long familyApplyId,
@@ -39,14 +40,27 @@ public class FamilyApplyRepositoryImpl implements FamilyApplyRepository {
         return familyApplyJpaRepository.existsByFamilyApplyIdAndApplyType(familyApplyId, applyType);
     }
 
-    /** ADD 요청의 승인 후처리에 필요한 최소 정보를 조회한다. */
+    /** 요청 ID와 요청 유형으로 가족 요청 도메인 객체를 조회한다. */
+    @Override
+    public Optional<FamilyApply> findFamilyRequest(Long familyApplyId, ApplyType applyType) {
+        return familyApplyJpaRepository.findByFamilyApplyIdAndApplyType(familyApplyId, applyType)
+                .map(FamilyApplyEntity::entityToDomain);
+    }
+
+    /** 요청 ID와 요청 유형으로 대상 이름을 조회한다. */
+    @Override
+    public Optional<String> findFamilyRequestTargetName(Long familyApplyId, ApplyType applyType) {
+        return familyApplyJpaRepository.findTargetNameByFamilyApplyIdAndApplyType(familyApplyId, applyType);
+    }
+
+    /** ADD 요청 승인 후처리에 필요한 최소 정보를 조회한다. */
     @Override
     public Optional<FamilyAddApprovalInfo> findAddApprovalInfo(Long familyApplyId) {
         return familyApplyJpaRepository.findByFamilyApplyIdAndApplyType(familyApplyId, ApplyType.ADD)
                 .map(this::toAddApprovalInfo);
     }
 
-    /** family_apply 엔티티를 승인 후처리용 정보 DTO로 변환한다. */
+    /** family_apply 엔티티를 승인 후처리용 DTO로 변환한다. */
     private FamilyAddApprovalInfo toAddApprovalInfo(FamilyApplyEntity entity) {
         return FamilyAddApprovalInfo.builder()
                 .familyId(entity.getFamily().getFamilyId())

--- a/src/main/java/hotspot/admin/family/outbox/FamilyRequestOutboxPublisher.java
+++ b/src/main/java/hotspot/admin/family/outbox/FamilyRequestOutboxPublisher.java
@@ -1,0 +1,59 @@
+package hotspot.admin.family.outbox;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import hotspot.admin.common.exception.ApplicationException;
+import hotspot.admin.common.exception.code.OutboxErrorCode;
+import hotspot.admin.family.domain.FamilyApply;
+import hotspot.admin.family.outbox.dto.FamilyRequestAlertEvent;
+import hotspot.admin.outbox.service.NotificationOutboxEventAppender;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilyRequestOutboxPublisher {
+
+    private static final String AGGREGATE_TYPE = "user-alert";
+    private static final String TYPE_APPROVED = "APPROVED";
+    private static final String TYPE_REJECTED = "REJECTED";
+
+    private final NotificationOutboxEventAppender outboxEventAppender;
+
+    // 가족 요청이 승인되었음을 알리는 Outbox 이벤트 발행을 수행한다.
+    public void publishApproved(FamilyApply familyApply, String targetName) {
+        publish(TYPE_APPROVED, familyApply, targetName);
+    }
+
+    // 가족 요청이 반려되었음을 알리는 Outbox 이벤트 발행을 수행한다.
+    public void publishRejected(FamilyApply familyApply, String targetName) {
+        publish(TYPE_REJECTED, familyApply, targetName);
+    }
+
+    // 승인/반려 타입에 맞는 알림 이벤트를 생성해 Outbox에 적재하고, 실패 시 예외를 공통 처리한다.
+    private void publish(String type, FamilyApply familyApply, String targetName) {
+        try {
+            FamilyRequestAlertEvent event = new FamilyRequestAlertEvent(
+                    UUID.randomUUID().toString(),
+                    type,
+                    familyApply.getApplyType().name(),
+                    targetName,
+                    familyApply.getFamilyId(),
+                    LocalDateTime.now()
+            );
+
+            outboxEventAppender.append(
+                    AGGREGATE_TYPE,
+                    String.valueOf(familyApply.getFamilyApplyId()),
+                    type,
+                    event
+            );
+        } catch (ApplicationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new ApplicationException(OutboxErrorCode.OUTBOX_EVENT_PUBLISH_FAILED, ex);
+        }
+    }
+}

--- a/src/main/java/hotspot/admin/family/outbox/dto/FamilyRequestAlertEvent.java
+++ b/src/main/java/hotspot/admin/family/outbox/dto/FamilyRequestAlertEvent.java
@@ -1,0 +1,13 @@
+package hotspot.admin.family.outbox.dto;
+
+import java.time.LocalDateTime;
+
+public record FamilyRequestAlertEvent(
+        String alertId,
+        String eventType,
+        String alertType,
+        String targetName,
+        Long familyId,
+        LocalDateTime createdTime
+) {
+}

--- a/src/main/java/hotspot/admin/family/service/ProcessFamilyRequestServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/ProcessFamilyRequestServiceImpl.java
@@ -5,10 +5,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.admin.common.exception.ApplicationException;
 import hotspot.admin.common.exception.code.FamilyErrorCode;
+import hotspot.admin.common.exception.code.OutboxErrorCode;
 import hotspot.admin.family.controller.port.ProcessFamilyRequestService;
 import hotspot.admin.family.domain.ApplyType;
+import hotspot.admin.family.domain.FamilyApply;
 import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.domain.PriorityType;
+import hotspot.admin.family.outbox.FamilyRequestOutboxPublisher;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
 import hotspot.admin.family.service.port.FamilyApplyRepository;
 import hotspot.admin.family.service.port.FamilyRepository;
@@ -28,6 +31,7 @@ public class ProcessFamilyRequestServiceImpl implements ProcessFamilyRequestServ
     private final FamilyApplyRepository familyApplyRepository;
     private final FamilyRepository familyRepository;
     private final FamilySubRepository familySubRepository;
+    private final FamilyRequestOutboxPublisher familyRequestOutboxPublisher;
 
     /** 가족 요청을 승인 상태로 전환한다. */
     @Override
@@ -46,7 +50,7 @@ public class ProcessFamilyRequestServiceImpl implements ProcessFamilyRequestServ
         processRequest(applyType, requestId, FamilyApplyStatus.REJECTED);
     }
 
-    /** 대기중 요청만 목표 상태로 전환하며, 실패 시 원인을 예외로 구분한다. */
+    /** 대기중 요청만 목표 상태로 전환하고, 실패 시 원인을 구분해 예외를 던진다. */
     private void processRequest(
             ApplyType applyType,
             Long requestId,
@@ -61,7 +65,15 @@ public class ProcessFamilyRequestServiceImpl implements ProcessFamilyRequestServ
 
         if (updatedCount == 0) {
             handleNotUpdated(requestId, applyType);
+            return;
         }
+
+        FamilyApply familyApply = familyApplyRepository.findFamilyRequest(requestId, applyType)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_REQUEST_NOT_FOUND));
+        String targetName = familyApplyRepository.findFamilyRequestTargetName(requestId, applyType)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_REQUEST_NOT_FOUND));
+
+        publishOutbox(nextStatus, familyApply, targetName);
     }
 
     /** 업데이트 실패 시 요청 미존재/상태 불일치 원인을 구분해 예외를 던진다. */
@@ -72,7 +84,20 @@ public class ProcessFamilyRequestServiceImpl implements ProcessFamilyRequestServ
         throw new ApplicationException(FamilyErrorCode.FAMILY_REQUEST_NOT_PENDING);
     }
 
-    /** ADD 승인 시 family_sub 삽입 후 family/family_sub 요약 값을 동기화한다. */
+    /** 다음 상태가 승인/반려인지에 따라 해당 Outbox 알림을 발행하고, 그 외 상태면 예외를 발생시킨다. */
+    private void publishOutbox(FamilyApplyStatus nextStatus, FamilyApply familyApply, String targetName) {
+        if (nextStatus == FamilyApplyStatus.APPROVED) {
+            familyRequestOutboxPublisher.publishApproved(familyApply, targetName);
+            return;
+        }
+        if (nextStatus == FamilyApplyStatus.REJECTED) {
+            familyRequestOutboxPublisher.publishRejected(familyApply, targetName);
+            return;
+        }
+        throw new ApplicationException(OutboxErrorCode.FAMILY_REQUEST_EVENT_BUILD_FAILED);
+    }
+
+    /** ADD 승인 시 family_sub 삽입 및 family/family_sub 요약 값을 동기화한다. */
     private void applyAddApproval(Long requestId) {
         FamilyAddApprovalInfo request = familyApplyRepository.findAddApprovalInfo(requestId)
                 .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_REQUEST_NOT_FOUND));

--- a/src/main/java/hotspot/admin/family/service/port/FamilyApplyRepository.java
+++ b/src/main/java/hotspot/admin/family/service/port/FamilyApplyRepository.java
@@ -3,6 +3,7 @@ package hotspot.admin.family.service.port;
 import java.util.Optional;
 
 import hotspot.admin.family.domain.ApplyType;
+import hotspot.admin.family.domain.FamilyApply;
 import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
 
@@ -15,6 +16,10 @@ public interface FamilyApplyRepository {
     );
 
     boolean existsFamilyRequest(Long familyApplyId, ApplyType applyType);
+
+    Optional<FamilyApply> findFamilyRequest(Long familyApplyId, ApplyType applyType);
+
+    Optional<String> findFamilyRequestTargetName(Long familyApplyId, ApplyType applyType);
 
     Optional<FamilyAddApprovalInfo> findAddApprovalInfo(Long familyApplyId);
 }

--- a/src/main/java/hotspot/admin/outbox/infrastructure/NotificationOutboxEventJpaRepository.java
+++ b/src/main/java/hotspot/admin/outbox/infrastructure/NotificationOutboxEventJpaRepository.java
@@ -1,0 +1,10 @@
+package hotspot.admin.outbox.infrastructure;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import hotspot.admin.outbox.infrastructure.entity.NotificationOutboxEventEntity;
+
+public interface NotificationOutboxEventJpaRepository extends JpaRepository<NotificationOutboxEventEntity, UUID> {
+}

--- a/src/main/java/hotspot/admin/outbox/infrastructure/entity/NotificationOutboxEventEntity.java
+++ b/src/main/java/hotspot/admin/outbox/infrastructure/entity/NotificationOutboxEventEntity.java
@@ -1,0 +1,39 @@
+package hotspot.admin.outbox.infrastructure.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "notification_outbox_event")
+public class NotificationOutboxEventEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "aggregatetype", nullable = false, length = 100)
+    private String aggregateType;
+
+    @Column(name = "aggregateid", nullable = false, length = 100)
+    private String aggregateId;
+
+    @Column(name = "type", nullable = false, length = 100)
+    private String type;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+}

--- a/src/main/java/hotspot/admin/outbox/service/NotificationOutboxEventAppender.java
+++ b/src/main/java/hotspot/admin/outbox/service/NotificationOutboxEventAppender.java
@@ -1,0 +1,51 @@
+package hotspot.admin.outbox.service;
+
+import java.util.UUID;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.admin.common.exception.ApplicationException;
+import hotspot.admin.common.exception.code.OutboxErrorCode;
+import hotspot.admin.outbox.infrastructure.NotificationOutboxEventJpaRepository;
+import hotspot.admin.outbox.infrastructure.entity.NotificationOutboxEventEntity;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationOutboxEventAppender {
+
+    private final NotificationOutboxEventJpaRepository outboxEventJpaRepository;
+    private final ObjectMapper objectMapper;
+
+    // 단일 outbox 이벤트 레코드를 outbox_event 테이블에 저장한다.
+    public void append(String aggregateType, String aggregateId, String type, Object payload) {
+        try {
+            outboxEventJpaRepository.save(
+                    NotificationOutboxEventEntity.builder()
+                            .id(UUID.randomUUID())
+                            .aggregateType(aggregateType)
+                            .aggregateId(aggregateId)
+                            .type(type)
+                            .payload(toJson(payload))
+                            .build()
+            );
+        } catch (DataAccessException ex) {
+            throw new ApplicationException(OutboxErrorCode.OUTBOX_EVENT_SAVE_FAILED, ex);
+        }
+    }
+
+    // payload 객체를 JSON 문자열로 직렬화한다.
+    private String toJson(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            throw new ApplicationException(OutboxErrorCode.OUTBOX_PAYLOAD_SERIALIZATION_FAILED, ex);
+        }
+    }
+}

--- a/src/test/java/hotspot/admin/family/outbox/FamilyRequestOutboxPublisherTest.java
+++ b/src/test/java/hotspot/admin/family/outbox/FamilyRequestOutboxPublisherTest.java
@@ -1,0 +1,122 @@
+package hotspot.admin.family.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.admin.common.exception.ApplicationException;
+import hotspot.admin.common.exception.code.OutboxErrorCode;
+import hotspot.admin.family.domain.ApplyType;
+import hotspot.admin.family.domain.FamilyApply;
+import hotspot.admin.family.domain.FamilyApplyStatus;
+import hotspot.admin.family.domain.FamilyRole;
+import hotspot.admin.family.outbox.dto.FamilyRequestAlertEvent;
+import hotspot.admin.outbox.service.NotificationOutboxEventAppender;
+
+@ExtendWith(MockitoExtension.class)
+class FamilyRequestOutboxPublisherTest {
+
+    @Mock
+    private NotificationOutboxEventAppender outboxEventAppender;
+
+    private FamilyRequestOutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new FamilyRequestOutboxPublisher(outboxEventAppender);
+    }
+
+    @Test
+    @DisplayName("승인 이벤트 outbox 적재")
+    void publishApprovedSuccess() {
+        FamilyApply familyApply = familyApply(11L, 101L, ApplyType.ADD);
+
+        publisher.publishApproved(familyApply, "target-name");
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(outboxEventAppender).append(
+                eq("user-alert"),
+                eq("11"),
+                eq("APPROVED"),
+                payloadCaptor.capture()
+        );
+
+        FamilyRequestAlertEvent event = (FamilyRequestAlertEvent) payloadCaptor.getValue();
+        assertThat(event.alertId()).isNotBlank();
+        assertThat(event.eventType()).isEqualTo("APPROVED");
+        assertThat(event.alertType()).isEqualTo("ADD");
+        assertThat(event.targetName()).isEqualTo("target-name");
+        assertThat(event.familyId()).isEqualTo(101L);
+        assertThat(event.createdTime()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("반려 이벤트 outbox 적재")
+    void publishRejectedSuccess() {
+        FamilyApply familyApply = familyApply(22L, 202L, ApplyType.REMOVE);
+
+        publisher.publishRejected(familyApply, "target-name-2");
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(outboxEventAppender).append(
+                eq("user-alert"),
+                eq("22"),
+                eq("REJECTED"),
+                payloadCaptor.capture()
+        );
+
+        FamilyRequestAlertEvent event = (FamilyRequestAlertEvent) payloadCaptor.getValue();
+        assertThat(event.eventType()).isEqualTo("REJECTED");
+        assertThat(event.alertType()).isEqualTo("REMOVE");
+    }
+
+    @Test
+    @DisplayName("ApplicationException은 그대로 전파")
+    void publishPropagateApplicationException() {
+        FamilyApply familyApply = familyApply(1L, 1L, ApplyType.ADD);
+        ApplicationException appEx = new ApplicationException(OutboxErrorCode.OUTBOX_EVENT_SAVE_FAILED);
+        doThrow(appEx).when(outboxEventAppender).append(any(), any(), any(), any());
+
+        assertThatThrownBy(() -> publisher.publishApproved(familyApply, "x"))
+                .isSameAs(appEx);
+    }
+
+    @Test
+    @DisplayName("기타 예외는 publish 실패 예외로 변환")
+    void publishWrapUnexpectedException() {
+        FamilyApply familyApply = familyApply(1L, 1L, ApplyType.ADD);
+        doThrow(new RuntimeException("boom")).when(outboxEventAppender).append(any(), any(), any(), any());
+
+        assertThatThrownBy(() -> publisher.publishApproved(familyApply, "x"))
+                .isInstanceOf(ApplicationException.class)
+                .matches(ex -> ((ApplicationException) ex).getCode() == OutboxErrorCode.OUTBOX_EVENT_PUBLISH_FAILED);
+    }
+
+    private FamilyApply familyApply(Long familyApplyId, Long familyId, ApplyType applyType) {
+        return FamilyApply.builder()
+                .familyApplyId(familyApplyId)
+                .requesterSubId(10L)
+                .targetSubId(20L)
+                .familyId(familyId)
+                .applyType(applyType)
+                .targetFamilyRole(FamilyRole.CHILD)
+                .docUrl(null)
+                .status(FamilyApplyStatus.PENDING)
+                .createdTime(LocalDateTime.now())
+                .modifiedTime(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/hotspot/admin/family/service/ProcessFamilyRequestServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/ProcessFamilyRequestServiceTest.java
@@ -1,10 +1,14 @@
 package hotspot.admin.family.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,9 +21,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hotspot.admin.common.exception.ApplicationException;
 import hotspot.admin.common.exception.code.FamilyErrorCode;
 import hotspot.admin.family.domain.ApplyType;
+import hotspot.admin.family.domain.FamilyApply;
 import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.domain.FamilyRole;
 import hotspot.admin.family.domain.PriorityType;
+import hotspot.admin.family.outbox.FamilyRequestOutboxPublisher;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
 import hotspot.admin.family.service.port.FamilyApplyRepository;
 import hotspot.admin.family.service.port.FamilyRepository;
@@ -37,6 +43,9 @@ class ProcessFamilyRequestServiceTest {
     @Mock
     private FamilySubRepository familySubRepository;
 
+    @Mock
+    private FamilyRequestOutboxPublisher familyRequestOutboxPublisher;
+
     private ProcessFamilyRequestServiceImpl service;
 
     @BeforeEach
@@ -44,19 +53,36 @@ class ProcessFamilyRequestServiceTest {
         service = new ProcessFamilyRequestServiceImpl(
                 familyApplyRepository,
                 familyRepository,
-                familySubRepository
+                familySubRepository,
+                familyRequestOutboxPublisher
         );
     }
 
     @Test
     @DisplayName("대기중 신청 요청 승인 성공")
     void approveSuccess() {
+        FamilyApply familyApply = FamilyApply.builder()
+                .familyApplyId(7L)
+                .requesterSubId(10L)
+                .targetSubId(100L)
+                .familyId(3L)
+                .applyType(ApplyType.ADD)
+                .targetFamilyRole(FamilyRole.CHILD)
+                .status(FamilyApplyStatus.APPROVED)
+                .createdTime(LocalDateTime.now())
+                .modifiedTime(LocalDateTime.now())
+                .build();
+
         when(familyApplyRepository.updateFamilyRequestStatus(
                 7L,
                 ApplyType.ADD,
                 FamilyApplyStatus.PENDING,
                 FamilyApplyStatus.APPROVED
         )).thenReturn(1);
+        when(familyApplyRepository.findFamilyRequest(7L, ApplyType.ADD))
+                .thenReturn(Optional.of(familyApply));
+        when(familyApplyRepository.findFamilyRequestTargetName(7L, ApplyType.ADD))
+                .thenReturn(Optional.of("target-name"));
         when(familyApplyRepository.findAddApprovalInfo(7L))
                 .thenReturn(Optional.of(
                         FamilyAddApprovalInfo.builder()
@@ -80,6 +106,7 @@ class ProcessFamilyRequestServiceTest {
                 FamilyApplyStatus.PENDING,
                 FamilyApplyStatus.APPROVED
         );
+        verify(familyRequestOutboxPublisher).publishApproved(eq(familyApply), eq("target-name"));
         verify(familySubRepository).saveFamilySub(3L, 100L, FamilyRole.CHILD, -1, 0L);
         verify(familyRepository).updateFamilySummary(3L, 3, 15728640L);
         verify(familySubRepository).updateDataLimit(3L, 15728640L);
@@ -89,15 +116,32 @@ class ProcessFamilyRequestServiceTest {
     @Test
     @DisplayName("REMOVE 승인 시에는 후속 테이블 업데이트를 수행하지 않는다")
     void approveRemoveNoFollowUp() {
+        FamilyApply familyApply = FamilyApply.builder()
+                .familyApplyId(5L)
+                .requesterSubId(20L)
+                .targetSubId(200L)
+                .familyId(6L)
+                .applyType(ApplyType.REMOVE)
+                .targetFamilyRole(FamilyRole.CHILD)
+                .status(FamilyApplyStatus.APPROVED)
+                .createdTime(LocalDateTime.now())
+                .modifiedTime(LocalDateTime.now())
+                .build();
+
         when(familyApplyRepository.updateFamilyRequestStatus(
                 5L,
                 ApplyType.REMOVE,
                 FamilyApplyStatus.PENDING,
                 FamilyApplyStatus.APPROVED
         )).thenReturn(1);
+        when(familyApplyRepository.findFamilyRequest(5L, ApplyType.REMOVE))
+                .thenReturn(Optional.of(familyApply));
+        when(familyApplyRepository.findFamilyRequestTargetName(5L, ApplyType.REMOVE))
+                .thenReturn(Optional.of("remove-target"));
 
         service.approve(ApplyType.REMOVE, 5L);
 
+        verify(familyRequestOutboxPublisher).publishApproved(eq(familyApply), eq("remove-target"));
         verifyNoInteractions(familyRepository, familySubRepository);
     }
 
@@ -116,6 +160,7 @@ class ProcessFamilyRequestServiceTest {
         assertThatThrownBy(() -> service.reject(ApplyType.REMOVE, 9L))
                 .isInstanceOf(ApplicationException.class)
                 .matches(ex -> ((ApplicationException) ex).getCode() == FamilyErrorCode.FAMILY_REQUEST_NOT_FOUND);
+        verify(familyRequestOutboxPublisher, never()).publishRejected(any(), any());
     }
 
     @Test
@@ -133,5 +178,6 @@ class ProcessFamilyRequestServiceTest {
         assertThatThrownBy(() -> service.reject(ApplyType.REMOVE, 9L))
                 .isInstanceOf(ApplicationException.class)
                 .matches(ex -> ((ApplicationException) ex).getCode() == FamilyErrorCode.FAMILY_REQUEST_NOT_PENDING);
+        verify(familyRequestOutboxPublisher, never()).publishRejected(any(), any());
     }
 }

--- a/src/test/java/hotspot/admin/outbox/service/NotificationOutboxEventAppenderTest.java
+++ b/src/test/java/hotspot/admin/outbox/service/NotificationOutboxEventAppenderTest.java
@@ -1,0 +1,88 @@
+package hotspot.admin.outbox.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.admin.common.exception.ApplicationException;
+import hotspot.admin.common.exception.code.OutboxErrorCode;
+import hotspot.admin.outbox.infrastructure.NotificationOutboxEventJpaRepository;
+import hotspot.admin.outbox.infrastructure.entity.NotificationOutboxEventEntity;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationOutboxEventAppenderTest {
+
+    @Mock
+    private NotificationOutboxEventJpaRepository outboxEventJpaRepository;
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private NotificationOutboxEventAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        appender = new NotificationOutboxEventAppender(outboxEventJpaRepository, objectMapper);
+    }
+
+    @Test
+    @DisplayName("outbox 이벤트 저장 성공")
+    void appendSuccess() throws Exception {
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"ok\":true}");
+
+        appender.append("user-alert", "7", "APPROVED", new Object());
+
+        ArgumentCaptor<NotificationOutboxEventEntity> captor =
+                ArgumentCaptor.forClass(NotificationOutboxEventEntity.class);
+        verify(outboxEventJpaRepository).save(captor.capture());
+
+        NotificationOutboxEventEntity saved = captor.getValue();
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getAggregateType()).isEqualTo("user-alert");
+        assertThat(saved.getAggregateId()).isEqualTo("7");
+        assertThat(saved.getType()).isEqualTo("APPROVED");
+        assertThat(saved.getPayload()).isEqualTo("{\"ok\":true}");
+    }
+
+    @Test
+    @DisplayName("payload 직렬화 실패 시 예외")
+    void appendSerializationFail() throws Exception {
+        when(objectMapper.writeValueAsString(any())).thenThrow(new JsonProcessingException("json error") {
+        });
+
+        assertThatThrownBy(
+                () -> appender.append("user-alert", "1", "APPROVED", new Object())
+        )
+                .isInstanceOf(ApplicationException.class)
+                .matches(ex ->
+                        ((ApplicationException) ex).getCode() == OutboxErrorCode.OUTBOX_PAYLOAD_SERIALIZATION_FAILED);
+    }
+
+    @Test
+    @DisplayName("DB 저장 실패 시 예외")
+    void appendSaveFail() throws Exception {
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"ok\":true}");
+        when(outboxEventJpaRepository.save(any()))
+                .thenThrow(new DataAccessResourceFailureException("db error"));
+
+        assertThatThrownBy(
+                () -> appender.append("user-alert", "1", "APPROVED", new Object())
+        )
+                .isInstanceOf(ApplicationException.class)
+                .matches(ex ->
+                        ((ApplicationException) ex).getCode() == OutboxErrorCode.OUTBOX_EVENT_SAVE_FAILED);
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-176

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #33 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 가족 요청 승인/반려 시 notification_outbox_event 테이블 적재 로직 추가
- Family 도메인 리팩토링 구조에 맞춰 Outbox 연동 재조립
- FamilyApplyRepository에 요청 상세/대상 이름 조회 메서드 확장
- FamilyApplyJpaRepository에 대상 이름 조회 쿼리 추가
- ProcessFamilyRequestServiceImpl에 상태 변경 성공 후 Outbox 발행 흐름 통합
- Outbox 공통 저장 모듈 추가
- Outbox 전용 예외 코드 및 예외 cause 체이닝 지원 추가
- 서비스/퍼블리셔/Appender 단위 테스트 추가 및 기존 테스트 보강

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
