### PR TITLE
[HOTSPOT-176] 가족 요청 OutBox 데이터 조회를 단일 쿼리로 통합

### DIFF
--- a/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyJpaRepository.java
+++ b/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyJpaRepository.java
@@ -39,8 +39,10 @@ public interface FamilyApplyJpaRepository extends JpaRepository<FamilyApplyEntit
     @Query("""
             SELECT fa
             FROM FamilyApplyEntity fa
+            JOIN FETCH fa.requesterSubscription rs
             JOIN FETCH fa.targetSubscription s
             JOIN FETCH s.member m
+            JOIN FETCH fa.family f
             WHERE fa.familyApplyId = :familyApplyId
               AND fa.applyType = :applyType
             """)

--- a/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyJpaRepository.java
+++ b/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyJpaRepository.java
@@ -35,20 +35,20 @@ public interface FamilyApplyJpaRepository extends JpaRepository<FamilyApplyEntit
     /** 요청 ID와 요청 유형으로 요청 존재 여부를 확인한다. */
     boolean existsByFamilyApplyIdAndApplyType(Long familyApplyId, ApplyType applyType);
 
-    /** 요청 ID와 요청 유형으로 요청 엔티티를 조회한다. */
-    Optional<FamilyApplyEntity> findByFamilyApplyIdAndApplyType(Long familyApplyId, ApplyType applyType);
-
-    /** 요청 ID와 요청 유형으로 대상 이름을 조회한다. */
+    /** 요청 ID와 요청 유형으로 Outbox 생성에 필요한 정보를 단건 조회한다. */
     @Query("""
-            SELECT m.name
+            SELECT fa
             FROM FamilyApplyEntity fa
-            JOIN fa.targetSubscription s
-            JOIN s.member m
+            JOIN FETCH fa.targetSubscription s
+            JOIN FETCH s.member m
             WHERE fa.familyApplyId = :familyApplyId
               AND fa.applyType = :applyType
             """)
-    Optional<String> findTargetNameByFamilyApplyIdAndApplyType(
+    Optional<FamilyApplyEntity> findOutboxSourceByFamilyApplyIdAndApplyType(
             @Param("familyApplyId") Long familyApplyId,
             @Param("applyType") ApplyType applyType
     );
+
+    /** 요청 ID와 요청 유형으로 요청 엔티티를 조회한다. */
+    Optional<FamilyApplyEntity> findByFamilyApplyIdAndApplyType(Long familyApplyId, ApplyType applyType);
 }

--- a/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyRepositoryImpl.java
+++ b/src/main/java/hotspot/admin/family/infrastructure/jpa/FamilyApplyRepositoryImpl.java
@@ -5,10 +5,10 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import hotspot.admin.family.domain.ApplyType;
-import hotspot.admin.family.domain.FamilyApply;
 import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.infrastructure.entity.FamilyApplyEntity;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
+import hotspot.admin.family.service.dto.FamilyRequestOutboxInfo;
 import hotspot.admin.family.service.port.FamilyApplyRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -40,17 +40,11 @@ public class FamilyApplyRepositoryImpl implements FamilyApplyRepository {
         return familyApplyJpaRepository.existsByFamilyApplyIdAndApplyType(familyApplyId, applyType);
     }
 
-    /** 요청 ID와 요청 유형으로 가족 요청 도메인 객체를 조회한다. */
+    /** 요청 ID와 요청 유형으로 Outbox 생성에 필요한 정보를 조회한다. */
     @Override
-    public Optional<FamilyApply> findFamilyRequest(Long familyApplyId, ApplyType applyType) {
-        return familyApplyJpaRepository.findByFamilyApplyIdAndApplyType(familyApplyId, applyType)
-                .map(FamilyApplyEntity::entityToDomain);
-    }
-
-    /** 요청 ID와 요청 유형으로 대상 이름을 조회한다. */
-    @Override
-    public Optional<String> findFamilyRequestTargetName(Long familyApplyId, ApplyType applyType) {
-        return familyApplyJpaRepository.findTargetNameByFamilyApplyIdAndApplyType(familyApplyId, applyType);
+    public Optional<FamilyRequestOutboxInfo> findFamilyRequestOutboxInfo(Long familyApplyId, ApplyType applyType) {
+        return familyApplyJpaRepository.findOutboxSourceByFamilyApplyIdAndApplyType(familyApplyId, applyType)
+                .map(this::toFamilyRequestOutboxInfo);
     }
 
     /** ADD 요청 승인 후처리에 필요한 최소 정보를 조회한다. */
@@ -67,5 +61,12 @@ public class FamilyApplyRepositoryImpl implements FamilyApplyRepository {
                 .targetSubId(entity.getTargetSubscription().getSubId())
                 .targetFamilyRole(entity.getTargetFamilyRole())
                 .build();
+    }
+
+    private FamilyRequestOutboxInfo toFamilyRequestOutboxInfo(FamilyApplyEntity entity) {
+        return new FamilyRequestOutboxInfo(
+                entity.entityToDomain(),
+                entity.getTargetSubscription().getMember().getName()
+        );
     }
 }

--- a/src/main/java/hotspot/admin/family/service/ProcessFamilyRequestServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/ProcessFamilyRequestServiceImpl.java
@@ -13,6 +13,7 @@ import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.domain.PriorityType;
 import hotspot.admin.family.outbox.FamilyRequestOutboxPublisher;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
+import hotspot.admin.family.service.dto.FamilyRequestOutboxInfo;
 import hotspot.admin.family.service.port.FamilyApplyRepository;
 import hotspot.admin.family.service.port.FamilyRepository;
 import hotspot.admin.family.service.port.FamilySubRepository;
@@ -68,12 +69,10 @@ public class ProcessFamilyRequestServiceImpl implements ProcessFamilyRequestServ
             return;
         }
 
-        FamilyApply familyApply = familyApplyRepository.findFamilyRequest(requestId, applyType)
-                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_REQUEST_NOT_FOUND));
-        String targetName = familyApplyRepository.findFamilyRequestTargetName(requestId, applyType)
+        FamilyRequestOutboxInfo outboxInfo = familyApplyRepository.findFamilyRequestOutboxInfo(requestId, applyType)
                 .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_REQUEST_NOT_FOUND));
 
-        publishOutbox(nextStatus, familyApply, targetName);
+        publishOutbox(nextStatus, outboxInfo.familyApply(), outboxInfo.targetName());
     }
 
     /** 업데이트 실패 시 요청 미존재/상태 불일치 원인을 구분해 예외를 던진다. */

--- a/src/main/java/hotspot/admin/family/service/dto/FamilyRequestOutboxInfo.java
+++ b/src/main/java/hotspot/admin/family/service/dto/FamilyRequestOutboxInfo.java
@@ -1,0 +1,9 @@
+package hotspot.admin.family.service.dto;
+
+import hotspot.admin.family.domain.FamilyApply;
+
+public record FamilyRequestOutboxInfo(
+        FamilyApply familyApply,
+        String targetName
+) {
+}

--- a/src/main/java/hotspot/admin/family/service/port/FamilyApplyRepository.java
+++ b/src/main/java/hotspot/admin/family/service/port/FamilyApplyRepository.java
@@ -3,9 +3,9 @@ package hotspot.admin.family.service.port;
 import java.util.Optional;
 
 import hotspot.admin.family.domain.ApplyType;
-import hotspot.admin.family.domain.FamilyApply;
 import hotspot.admin.family.domain.FamilyApplyStatus;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
+import hotspot.admin.family.service.dto.FamilyRequestOutboxInfo;
 
 public interface FamilyApplyRepository {
     int updateFamilyRequestStatus(
@@ -17,9 +17,7 @@ public interface FamilyApplyRepository {
 
     boolean existsFamilyRequest(Long familyApplyId, ApplyType applyType);
 
-    Optional<FamilyApply> findFamilyRequest(Long familyApplyId, ApplyType applyType);
-
-    Optional<String> findFamilyRequestTargetName(Long familyApplyId, ApplyType applyType);
+    Optional<FamilyRequestOutboxInfo> findFamilyRequestOutboxInfo(Long familyApplyId, ApplyType applyType);
 
     Optional<FamilyAddApprovalInfo> findAddApprovalInfo(Long familyApplyId);
 }

--- a/src/test/java/hotspot/admin/family/infrastructure/FamilyApplyRepositoryImplTest.java
+++ b/src/test/java/hotspot/admin/family/infrastructure/FamilyApplyRepositoryImplTest.java
@@ -19,6 +19,8 @@ import hotspot.admin.family.infrastructure.entity.FamilyEntity;
 import hotspot.admin.family.infrastructure.jpa.FamilyApplyJpaRepository;
 import hotspot.admin.family.infrastructure.jpa.FamilyApplyRepositoryImpl;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
+import hotspot.admin.family.service.dto.FamilyRequestOutboxInfo;
+import hotspot.admin.member.infrastructure.entity.MemberEntity;
 import hotspot.admin.subscription.infrastructure.entity.SubscriptionEntity;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,5 +88,59 @@ class FamilyApplyRepositoryImplTest {
         assertThat(result.get().familyId()).isEqualTo(3L);
         assertThat(result.get().targetSubId()).isEqualTo(10L);
         assertThat(result.get().targetFamilyRole()).isEqualTo(FamilyRole.CHILD);
+    }
+
+    @Test
+    @DisplayName("Outbox 생성용 요청 정보 조회 성공")
+    void findFamilyRequestOutboxInfoSuccess() {
+        FamilyApplyRepositoryImpl familyApplyRepository = new FamilyApplyRepositoryImpl(familyApplyJpaRepository);
+
+        MemberEntity requesterMember = MemberEntity.builder()
+                .memberId(1L)
+                .name("requester")
+                .birth("900101")
+                .build();
+        MemberEntity targetMember = MemberEntity.builder()
+                .memberId(2L)
+                .name("target-name")
+                .birth("900102")
+                .build();
+
+        SubscriptionEntity requesterSubscription = SubscriptionEntity.builder()
+                .subId(11L)
+                .member(requesterMember)
+                .build();
+        SubscriptionEntity targetSubscription = SubscriptionEntity.builder()
+                .subId(22L)
+                .member(targetMember)
+                .build();
+        FamilyEntity family = FamilyEntity.builder()
+                .familyId(33L)
+                .build();
+
+        FamilyApplyEntity entity = FamilyApplyEntity.builder()
+                .familyApplyId(44L)
+                .requesterSubscription(requesterSubscription)
+                .targetSubscription(targetSubscription)
+                .family(family)
+                .applyType(ApplyType.ADD)
+                .targetFamilyRole(FamilyRole.CHILD)
+                .status(FamilyApplyStatus.PENDING)
+                .build();
+
+        when(familyApplyJpaRepository.findOutboxSourceByFamilyApplyIdAndApplyType(44L, ApplyType.ADD))
+                .thenReturn(Optional.of(entity));
+
+        Optional<FamilyRequestOutboxInfo> result = familyApplyRepository.findFamilyRequestOutboxInfo(
+                44L,
+                ApplyType.ADD
+        );
+
+        assertThat(result).isPresent();
+        assertThat(result.get().targetName()).isEqualTo("target-name");
+        assertThat(result.get().familyApply().getFamilyApplyId()).isEqualTo(44L);
+        assertThat(result.get().familyApply().getRequesterSubId()).isEqualTo(11L);
+        assertThat(result.get().familyApply().getTargetSubId()).isEqualTo(22L);
+        assertThat(result.get().familyApply().getFamilyId()).isEqualTo(33L);
     }
 }

--- a/src/test/java/hotspot/admin/family/service/ProcessFamilyRequestServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/ProcessFamilyRequestServiceTest.java
@@ -27,6 +27,7 @@ import hotspot.admin.family.domain.FamilyRole;
 import hotspot.admin.family.domain.PriorityType;
 import hotspot.admin.family.outbox.FamilyRequestOutboxPublisher;
 import hotspot.admin.family.service.dto.FamilyAddApprovalInfo;
+import hotspot.admin.family.service.dto.FamilyRequestOutboxInfo;
 import hotspot.admin.family.service.port.FamilyApplyRepository;
 import hotspot.admin.family.service.port.FamilyRepository;
 import hotspot.admin.family.service.port.FamilySubRepository;
@@ -79,10 +80,8 @@ class ProcessFamilyRequestServiceTest {
                 FamilyApplyStatus.PENDING,
                 FamilyApplyStatus.APPROVED
         )).thenReturn(1);
-        when(familyApplyRepository.findFamilyRequest(7L, ApplyType.ADD))
-                .thenReturn(Optional.of(familyApply));
-        when(familyApplyRepository.findFamilyRequestTargetName(7L, ApplyType.ADD))
-                .thenReturn(Optional.of("target-name"));
+        when(familyApplyRepository.findFamilyRequestOutboxInfo(7L, ApplyType.ADD))
+                .thenReturn(Optional.of(new FamilyRequestOutboxInfo(familyApply, "target-name")));
         when(familyApplyRepository.findAddApprovalInfo(7L))
                 .thenReturn(Optional.of(
                         FamilyAddApprovalInfo.builder()
@@ -134,10 +133,8 @@ class ProcessFamilyRequestServiceTest {
                 FamilyApplyStatus.PENDING,
                 FamilyApplyStatus.APPROVED
         )).thenReturn(1);
-        when(familyApplyRepository.findFamilyRequest(5L, ApplyType.REMOVE))
-                .thenReturn(Optional.of(familyApply));
-        when(familyApplyRepository.findFamilyRequestTargetName(5L, ApplyType.REMOVE))
-                .thenReturn(Optional.of("remove-target"));
+        when(familyApplyRepository.findFamilyRequestOutboxInfo(5L, ApplyType.REMOVE))
+                .thenReturn(Optional.of(new FamilyRequestOutboxInfo(familyApply, "remove-target")));
 
         service.approve(ApplyType.REMOVE, 5L);
 


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-176

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 가족 요청 Outbox 데이터 조회를 단일 쿼리(findOutboxSourceByFamilyApplyIdAndApplyType)로 통합
- Outbox 조회 결과를 FamilyRequestOutboxInfo로 매핑하도록 리포지토리 구현 리팩토링
- 승인/반려 처리 시 가족 요청 조회와 대상 이름 조회를 1회 조회 기반으로 변경
- Outbox용 단일 조회 포트(findFamilyRequestOutboxInfo)로 인터페이스 정리
- 가족 요청 도메인 정보와 대상 이름을 함께 전달하는 Outbox 조회 DTO 추가

- Outbox 단일 조회 매핑 검증 테스트 추가로 커버리지 보강
- 서비스 테스트를 단일 조회 포트 사용 시나리오에 맞게 수정

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
