### PR TITLE
[HOTSPOT-294] 전화번호 복호화를 subId 기반 DEK 방식으로 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
 	// DB
 	runtimeOnly 'org.postgresql:postgresql'
+	implementation 'software.amazon.awssdk:kms:2.31.2'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/hotspot/admin/common/util/PhoneCryptoUtil.java
+++ b/src/main/java/hotspot/admin/common/util/PhoneCryptoUtil.java
@@ -1,105 +1,170 @@
 package hotspot.admin.common.util;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.List;
 
 import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import hotspot.admin.subscription.service.port.SubscriptionPhoneKeyLookupRepository;
+import hotspot.admin.subscription.service.port.dto.SubscriptionPhoneKeyInfo;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.DecryptRequest;
+import software.amazon.awssdk.services.kms.model.KmsException;
 
 @Component
 @Slf4j
 public class PhoneCryptoUtil {
 
-    private static final int AES_BLOCK_SIZE = 16;
-    private static final int AES_KEY_SIZE_128 = 16;
-    private static final int AES_KEY_SIZE_192 = 24;
-    private static final int AES_KEY_SIZE_256 = 32;
     private static final String AES_ALGORITHM = "AES";
+    private static final int AES_BLOCK_SIZE = 16;
+    private static final int GCM_NONCE_SIZE = 12;
+    private static final int GCM_TAG_SIZE = 16;
+    private static final String GCM_PREFIX = "gcm:";
 
-    private final List<byte[]> keyCandidates;
+    private final SubscriptionPhoneKeyLookupRepository phoneKeyLookupRepository;
+    private final byte[] localSecretKey;
+    private final String encryptionProvider;
+    private final String configuredKmsKeyId;
 
-    public PhoneCryptoUtil(@Value("${project.phone-secret-key}") String encryptionKey) {
-        this.keyCandidates = resolveKeyCandidates(encryptionKey);
+    private volatile KmsClient kmsClient;
+
+    public PhoneCryptoUtil(
+            SubscriptionPhoneKeyLookupRepository phoneKeyLookupRepository,
+            @Value("${project.phone-secret-key}") String phoneSecretKey,
+            @Value("${project.encryption-provider:local}") String encryptionProvider,
+            @Value("${project.kms-key-id:}") String configuredKmsKeyId
+    ) {
+        this.phoneKeyLookupRepository = phoneKeyLookupRepository;
+        this.localSecretKey = resolveKey(phoneSecretKey);
+        this.encryptionProvider = encryptionProvider == null ? "local" : encryptionProvider.trim().toLowerCase();
+        this.configuredKmsKeyId = configuredKmsKeyId == null ? "" : configuredKmsKeyId.trim();
     }
 
-    public String decryptPhone(String encryptedPhone) throws GeneralSecurityException {
-        byte[] decoded = Base64.getDecoder().decode(encryptedPhone);
-
-        for (byte[] keyBytes : keyCandidates) {
-            // Try IV + ciphertext format first.
-            if (decoded.length > AES_BLOCK_SIZE) {
-                byte[] iv = Arrays.copyOfRange(decoded, 0, AES_BLOCK_SIZE);
-                byte[] ciphertext = Arrays.copyOfRange(decoded, AES_BLOCK_SIZE, decoded.length);
-                try {
-                    return decryptAesCbc(ciphertext, iv, keyBytes);
-                } catch (GeneralSecurityException e) {
-                    log.trace("CBC decryption failed. Falling back to ECB mode.", e);
-                    // Fallback to ECB if storage format is ciphertext only.
-                }
-            }
-
-            try {
-                return decryptAesEcb(decoded, keyBytes);
-            } catch (GeneralSecurityException e) {
-                log.trace("ECB decryption failed with current key candidate.", e);
-                // Try next key candidate.
-            }
+    public String decryptPhone(String encryptedPhone, Long subId) throws GeneralSecurityException {
+        if (encryptedPhone == null || encryptedPhone.isBlank()) {
+            return encryptedPhone;
+        }
+        if (subId == null) {
+            throw new GeneralSecurityException("subId is required to decrypt phone.");
         }
 
-        throw new GeneralSecurityException("Unable to decrypt phone with configured key.");
+        SubscriptionPhoneKeyInfo phoneKeyInfo = phoneKeyLookupRepository.findPhoneKeyInfoBySubId(subId)
+                .orElseThrow(() -> new GeneralSecurityException("Phone key info not found for subId=" + subId));
+
+        byte[] dek = unwrapDek(phoneKeyInfo);
+        return decryptPayload(encryptedPhone, dek);
     }
 
-    private String decryptAesCbc(byte[] ciphertext, byte[] iv, byte[] keyBytes) throws GeneralSecurityException {
+    private byte[] unwrapDek(SubscriptionPhoneKeyInfo phoneKeyInfo) throws GeneralSecurityException {
+        if ("kms".equals(encryptionProvider)) {
+            return decryptDekWithKms(phoneKeyInfo);
+        }
+        return decryptPayloadBytes(phoneKeyInfo.encryptedDek(), localSecretKey);
+    }
+
+    private byte[] decryptDekWithKms(SubscriptionPhoneKeyInfo phoneKeyInfo) throws GeneralSecurityException {
+        String kmsKeyId = phoneKeyInfo.kekKeyId();
+        if (kmsKeyId == null || kmsKeyId.isBlank()) {
+            kmsKeyId = configuredKmsKeyId;
+        }
+
+        try {
+            DecryptRequest.Builder requestBuilder = DecryptRequest.builder()
+                    .ciphertextBlob(SdkBytes.fromByteArray(Base64.getDecoder().decode(phoneKeyInfo.encryptedDek())));
+            if (kmsKeyId != null && !kmsKeyId.isBlank()) {
+                requestBuilder.keyId(kmsKeyId);
+            }
+            return getKmsClient().decrypt(requestBuilder.build()).plaintext().asByteArray();
+        } catch (IllegalArgumentException | KmsException e) {
+            log.warn("KMS DEK decrypt failed for subId={}", phoneKeyInfo.subId(), e);
+            throw new GeneralSecurityException("Failed to decrypt DEK with KMS.", e);
+        }
+    }
+
+    private String decryptPayload(String cipherText, byte[] key) throws GeneralSecurityException {
+        return new String(decryptPayloadBytes(cipherText, key), StandardCharsets.UTF_8);
+    }
+
+    private byte[] decryptPayloadBytes(String cipherText, byte[] key) throws GeneralSecurityException {
+        if (cipherText.startsWith(GCM_PREFIX)) {
+            String encoded = cipherText.substring(GCM_PREFIX.length());
+            byte[] decoded = Base64.getDecoder().decode(encoded);
+            return decryptAesGcm(decoded, key);
+        }
+        return decryptAesCbc(Base64.getDecoder().decode(cipherText), key);
+    }
+
+    private byte[] decryptAesGcm(byte[] payload, byte[] key) throws GeneralSecurityException {
+        if (payload.length <= GCM_NONCE_SIZE + GCM_TAG_SIZE) {
+            throw new GeneralSecurityException("Invalid AES/GCM payload.");
+        }
+        byte[] nonce = Arrays.copyOfRange(payload, 0, GCM_NONCE_SIZE);
+        byte[] encrypted = Arrays.copyOfRange(payload, GCM_NONCE_SIZE, payload.length - GCM_TAG_SIZE);
+        byte[] tag = Arrays.copyOfRange(payload, payload.length - GCM_TAG_SIZE, payload.length);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(
+                Cipher.DECRYPT_MODE,
+                new SecretKeySpec(key, AES_ALGORITHM),
+                new GCMParameterSpec(GCM_TAG_SIZE * 8, nonce)
+        );
+        return cipher.doFinal(ByteBuffer.allocate(encrypted.length + tag.length).put(encrypted).put(tag).array());
+    }
+
+    private byte[] decryptAesCbc(byte[] payload, byte[] key) throws GeneralSecurityException {
+        if (payload.length <= AES_BLOCK_SIZE) {
+            throw new GeneralSecurityException("Invalid AES/CBC payload.");
+        }
+        byte[] iv = Arrays.copyOfRange(payload, 0, AES_BLOCK_SIZE);
+        byte[] ciphertext = Arrays.copyOfRange(payload, AES_BLOCK_SIZE, payload.length);
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-        SecretKeySpec keySpec = new SecretKeySpec(keyBytes, AES_ALGORITHM);
-        cipher.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(iv));
-        return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+        cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, AES_ALGORITHM), new IvParameterSpec(iv));
+        return cipher.doFinal(ciphertext);
     }
 
-    private String decryptAesEcb(byte[] ciphertext, byte[] keyBytes) throws GeneralSecurityException {
-        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
-        SecretKeySpec keySpec = new SecretKeySpec(keyBytes, AES_ALGORITHM);
-        cipher.init(Cipher.DECRYPT_MODE, keySpec);
-        return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
-    }
-
-    private List<byte[]> resolveKeyCandidates(String rawKey) {
-        List<byte[]> candidates = new ArrayList<>();
-
-        addIfValidKey(candidates, rawKey.getBytes(StandardCharsets.UTF_8));
+    private byte[] resolveKey(String rawKey) {
+        byte[] rawBytes = rawKey.getBytes(StandardCharsets.UTF_8);
+        if (isValidAesKeyLength(rawBytes.length)) {
+            return rawBytes;
+        }
 
         try {
             byte[] decoded = Base64.getDecoder().decode(rawKey);
-            addIfValidKey(candidates, decoded);
+            if (isValidAesKeyLength(decoded.length)) {
+                return decoded;
+            }
         } catch (IllegalArgumentException e) {
-            log.trace("PHONE_SECRET_KEY is not Base64 encoded. Raw key bytes only will be considered.");
+            log.trace("PHONE_SECRET_KEY is not Base64 encoded.");
         }
 
-        if (candidates.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "PHONE_SECRET_KEY length must be 16/24/32 bytes (raw or Base64-decoded).");
-        }
-
-        return candidates;
-    }
-
-    private void addIfValidKey(List<byte[]> candidates, byte[] key) {
-        if (isValidAesKeyLength(key.length)) {
-            candidates.add(key);
-        }
+        throw new IllegalArgumentException("PHONE_SECRET_KEY length must be 16/24/32 bytes.");
     }
 
     private boolean isValidAesKeyLength(int length) {
-        return length == AES_KEY_SIZE_128 || length == AES_KEY_SIZE_192 || length == AES_KEY_SIZE_256;
+        return length == 16 || length == 24 || length == 32;
+    }
+
+    private KmsClient getKmsClient() {
+        KmsClient current = kmsClient;
+        if (current != null) {
+            return current;
+        }
+        synchronized (this) {
+            if (kmsClient == null) {
+                kmsClient = KmsClient.builder().build();
+            }
+            return kmsClient;
+        }
     }
 }

--- a/src/main/java/hotspot/admin/common/util/PhoneCryptoUtil.java
+++ b/src/main/java/hotspot/admin/common/util/PhoneCryptoUtil.java
@@ -5,12 +5,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Objects;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -24,13 +26,18 @@ import software.amazon.awssdk.services.kms.model.KmsException;
 
 @Component
 @Slf4j
-public class PhoneCryptoUtil {
+public class PhoneCryptoUtil implements DisposableBean {
 
     private static final String AES_ALGORITHM = "AES";
     private static final int AES_BLOCK_SIZE = 16;
+    private static final int AES_KEY_SIZE_128 = 16;
+    private static final int AES_KEY_SIZE_192 = 24;
+    private static final int AES_KEY_SIZE_256 = 32;
     private static final int GCM_NONCE_SIZE = 12;
     private static final int GCM_TAG_SIZE = 16;
     private static final String GCM_PREFIX = "gcm:";
+    private static final String ENCRYPTION_PROVIDER_LOCAL = "local";
+    private static final String ENCRYPTION_PROVIDER_KMS = "kms";
 
     private final SubscriptionPhoneKeyLookupRepository phoneKeyLookupRepository;
     private final byte[] localSecretKey;
@@ -46,8 +53,10 @@ public class PhoneCryptoUtil {
             @Value("${project.kms-key-id:}") String configuredKmsKeyId
     ) {
         this.phoneKeyLookupRepository = phoneKeyLookupRepository;
-        this.localSecretKey = resolveKey(phoneSecretKey);
-        this.encryptionProvider = encryptionProvider == null ? "local" : encryptionProvider.trim().toLowerCase();
+        this.localSecretKey = parseAndValidateSecretKey(phoneSecretKey);
+        this.encryptionProvider = encryptionProvider == null
+                ? ENCRYPTION_PROVIDER_LOCAL
+                : encryptionProvider.trim().toLowerCase();
         this.configuredKmsKeyId = configuredKmsKeyId == null ? "" : configuredKmsKeyId.trim();
     }
 
@@ -67,7 +76,7 @@ public class PhoneCryptoUtil {
     }
 
     private byte[] unwrapDek(SubscriptionPhoneKeyInfo phoneKeyInfo) throws GeneralSecurityException {
-        if ("kms".equals(encryptionProvider)) {
+        if (ENCRYPTION_PROVIDER_KMS.equals(encryptionProvider)) {
             return decryptDekWithKms(phoneKeyInfo);
         }
         return decryptPayloadBytes(phoneKeyInfo.encryptedDek(), localSecretKey);
@@ -97,12 +106,19 @@ public class PhoneCryptoUtil {
     }
 
     private byte[] decryptPayloadBytes(String cipherText, byte[] key) throws GeneralSecurityException {
-        if (cipherText.startsWith(GCM_PREFIX)) {
-            String encoded = cipherText.substring(GCM_PREFIX.length());
-            byte[] decoded = Base64.getDecoder().decode(encoded);
-            return decryptAesGcm(decoded, key);
+        if (cipherText == null || cipherText.isBlank()) {
+            throw new GeneralSecurityException("Cipher text must not be null or blank.");
         }
-        return decryptAesCbc(Base64.getDecoder().decode(cipherText), key);
+        try {
+            if (cipherText.startsWith(GCM_PREFIX)) {
+                String encoded = cipherText.substring(GCM_PREFIX.length());
+                byte[] decoded = Base64.getDecoder().decode(encoded);
+                return decryptAesGcm(decoded, key);
+            }
+            return decryptAesCbc(Base64.getDecoder().decode(cipherText), key);
+        } catch (IllegalArgumentException e) {
+            throw new GeneralSecurityException("Invalid encrypted payload.", e);
+        }
     }
 
     private byte[] decryptAesGcm(byte[] payload, byte[] key) throws GeneralSecurityException {
@@ -133,7 +149,8 @@ public class PhoneCryptoUtil {
         return cipher.doFinal(ciphertext);
     }
 
-    private byte[] resolveKey(String rawKey) {
+    private byte[] parseAndValidateSecretKey(String rawKey) {
+        Objects.requireNonNull(rawKey, "PHONE_SECRET_KEY must not be null.");
         byte[] rawBytes = rawKey.getBytes(StandardCharsets.UTF_8);
         if (isValidAesKeyLength(rawBytes.length)) {
             return rawBytes;
@@ -152,7 +169,9 @@ public class PhoneCryptoUtil {
     }
 
     private boolean isValidAesKeyLength(int length) {
-        return length == 16 || length == 24 || length == 32;
+        return length == AES_KEY_SIZE_128
+                || length == AES_KEY_SIZE_192
+                || length == AES_KEY_SIZE_256;
     }
 
     private KmsClient getKmsClient() {
@@ -165,6 +184,14 @@ public class PhoneCryptoUtil {
                 kmsClient = KmsClient.builder().build();
             }
             return kmsClient;
+        }
+    }
+
+    @Override
+    public void destroy() {
+        KmsClient current = kmsClient;
+        if (current != null) {
+            current.close();
         }
     }
 }

--- a/src/main/java/hotspot/admin/family/controller/response/FamilyListItem.java
+++ b/src/main/java/hotspot/admin/family/controller/response/FamilyListItem.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record FamilyListItem(
         Long familyId,
+        Long subId,
         String displayId,
         String representativeName,
         String phoneNumber,

--- a/src/main/java/hotspot/admin/family/infrastructure/query/FamilyQueryRepositoryImpl.java
+++ b/src/main/java/hotspot/admin/family/infrastructure/query/FamilyQueryRepositoryImpl.java
@@ -31,6 +31,11 @@ public class FamilyQueryRepositoryImpl implements FamilyQueryRepository {
                             MIN(m.name)
                         ) AS representative_name,
                         COALESCE(
+                            MAX(CASE WHEN fs.family_role = :ownerRole THEN s.sub_id END),
+                            MAX(CASE WHEN fs.family_role = :parentRole THEN s.sub_id END),
+                            MIN(s.sub_id)
+                        ) AS phone_sub_id,
+                        COALESCE(
                             MAX(CASE WHEN fs.family_role = :ownerRole THEN s.phone_enc END),
                             MAX(CASE WHEN fs.family_role = :parentRole THEN s.phone_enc END),
                             MIN(s.phone_enc)
@@ -43,7 +48,7 @@ public class FamilyQueryRepositoryImpl implements FamilyQueryRepository {
                     WHERE f.is_deleted = false
                     GROUP BY f.family_id
                 )
-                SELECT family_id, representative_name, phone_number_enc, member_count
+                SELECT family_id, phone_sub_id, representative_name, phone_number_enc, member_count
                 FROM family_agg
                 ORDER BY family_id ASC
                 LIMIT :limit
@@ -85,6 +90,11 @@ public class FamilyQueryRepositoryImpl implements FamilyQueryRepository {
                             MIN(m.name)
                         ) AS representative_name,
                         COALESCE(
+                            MAX(CASE WHEN fs.family_role = :ownerRole THEN s.sub_id END),
+                            MAX(CASE WHEN fs.family_role = :parentRole THEN s.sub_id END),
+                            MIN(s.sub_id)
+                        ) AS phone_sub_id,
+                        COALESCE(
                             MAX(CASE WHEN fs.family_role = :ownerRole THEN s.phone_enc END),
                             MAX(CASE WHEN fs.family_role = :parentRole THEN s.phone_enc END),
                             MIN(s.phone_enc)
@@ -105,7 +115,7 @@ public class FamilyQueryRepositoryImpl implements FamilyQueryRepository {
                     )
                     GROUP BY f.family_id
                 )
-                SELECT family_id, representative_name, phone_number_enc, member_count
+                SELECT family_id, phone_sub_id, representative_name, phone_number_enc, member_count
                 FROM family_agg
                 ORDER BY family_id ASC
                 LIMIT 1
@@ -133,6 +143,11 @@ public class FamilyQueryRepositoryImpl implements FamilyQueryRepository {
                             MIN(m.name)
                         ) AS representative_name,
                         COALESCE(
+                            MAX(CASE WHEN fs.family_role = :ownerRole THEN s.sub_id END),
+                            MAX(CASE WHEN fs.family_role = :parentRole THEN s.sub_id END),
+                            MIN(s.sub_id)
+                        ) AS phone_sub_id,
+                        COALESCE(
                             MAX(CASE WHEN fs.family_role = :ownerRole THEN s.phone_enc END),
                             MAX(CASE WHEN fs.family_role = :parentRole THEN s.phone_enc END),
                             MIN(s.phone_enc)
@@ -146,7 +161,7 @@ public class FamilyQueryRepositoryImpl implements FamilyQueryRepository {
                       AND f.family_id = :familyId
                     GROUP BY f.family_id
                 )
-                SELECT family_id, representative_name, phone_number_enc, member_count
+                SELECT family_id, phone_sub_id, representative_name, phone_number_enc, member_count
                 FROM family_agg
                 LIMIT 1
                 """;
@@ -164,6 +179,7 @@ public class FamilyQueryRepositoryImpl implements FamilyQueryRepository {
     private FamilyListItem mapFamilyListItem(java.sql.ResultSet rs, int rowNum) throws java.sql.SQLException {
         return FamilyListItem.builder()
                 .familyId(rs.getLong("family_id"))
+                .subId(rs.getObject("phone_sub_id", Long.class))
                 .representativeName(rs.getString("representative_name"))
                 .phoneNumber(rs.getString("phone_number_enc"))
                 .memberCount(rs.getInt("member_count"))

--- a/src/main/java/hotspot/admin/family/service/GetFamilyListServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/GetFamilyListServiceImpl.java
@@ -56,6 +56,7 @@ public class GetFamilyListServiceImpl implements GetFamilyListService {
         if (item.phoneNumber() == null || item.phoneNumber().isBlank()) {
             return FamilyListItem.builder()
                     .familyId(item.familyId())
+                    .subId(item.subId())
                     .displayId(DisplayIdFormatter.format(DisplayIdType.FAMILY, item.familyId()))
                     .representativeName(item.representativeName())
                     .phoneNumber(item.phoneNumber())
@@ -64,10 +65,11 @@ public class GetFamilyListServiceImpl implements GetFamilyListService {
         }
 
         try {
-            String decrypted = phoneCryptoUtil.decryptPhone(item.phoneNumber());
+            String decrypted = phoneCryptoUtil.decryptPhone(item.phoneNumber(), item.subId());
             String masked = PhoneMaskingUtil.maskMiddle(decrypted);
             return FamilyListItem.builder()
                     .familyId(item.familyId())
+                    .subId(item.subId())
                     .displayId(DisplayIdFormatter.format(DisplayIdType.FAMILY, item.familyId()))
                     .representativeName(item.representativeName())
                     .phoneNumber(masked)

--- a/src/main/java/hotspot/admin/family/service/GetFamilyPolicyDetailStatusServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/GetFamilyPolicyDetailStatusServiceImpl.java
@@ -95,7 +95,7 @@ public class GetFamilyPolicyDetailStatusServiceImpl implements GetFamilyPolicyDe
 
         return FamilyPolicyMemberDetailItem.builder()
                 .memberName(member.memberName())
-                .phoneNumber(decryptAndMaskPhone(member.phoneNumberEnc()))
+                .phoneNumber(decryptAndMaskPhone(member.phoneNumberEnc(), member.subId()))
                 .familyRole(member.familyRole())
                 .blocked(blocked)
                 .appliedTimePolicies(toTimeItems(timePolicyOptions, memberTimePolicyIds))
@@ -161,13 +161,13 @@ public class GetFamilyPolicyDetailStatusServiceImpl implements GetFamilyPolicyDe
         }
     }
 
-    private String decryptAndMaskPhone(String encryptedPhone) {
+    private String decryptAndMaskPhone(String encryptedPhone, Long subId) {
         if (encryptedPhone == null || encryptedPhone.isBlank()) {
             return encryptedPhone;
         }
 
         try {
-            String decrypted = phoneCryptoUtil.decryptPhone(encryptedPhone);
+            String decrypted = phoneCryptoUtil.decryptPhone(encryptedPhone, subId);
             return PhoneMaskingUtil.maskMiddle(decrypted);
         } catch (GeneralSecurityException e) {
             throw new ApplicationException(FamilyErrorCode.PHONE_DECRYPT_FAILED);

--- a/src/main/java/hotspot/admin/family/service/GetFamilyPolicyStatusServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/GetFamilyPolicyStatusServiceImpl.java
@@ -52,7 +52,7 @@ public class GetFamilyPolicyStatusServiceImpl implements GetFamilyPolicyStatusSe
         return FamilyPolicyMemberStatusItem.builder()
                 .subId(member.subId())
                 .memberName(member.memberName())
-                .phoneNumber(decryptAndMaskPhone(member.phoneNumberEnc()))
+                .phoneNumber(decryptAndMaskPhone(member.phoneNumberEnc(), member.subId()))
                 .familyRole(member.familyRole())
                 .blocked(blocked)
                 .appliedTimePolicies(member.appliedTimePolicies())
@@ -61,13 +61,13 @@ public class GetFamilyPolicyStatusServiceImpl implements GetFamilyPolicyStatusSe
     }
 
     /** 암호화된 전화번호를 복호화하고 마스킹해 표시 형식으로 변환한다. */
-    private String decryptAndMaskPhone(String encryptedPhone) {
+    private String decryptAndMaskPhone(String encryptedPhone, Long subId) {
         if (encryptedPhone == null || encryptedPhone.isBlank()) {
             return encryptedPhone;
         }
 
         try {
-            String decrypted = phoneCryptoUtil.decryptPhone(encryptedPhone);
+            String decrypted = phoneCryptoUtil.decryptPhone(encryptedPhone, subId);
             return PhoneMaskingUtil.maskMiddle(decrypted);
         } catch (GeneralSecurityException e) {
             throw new ApplicationException(FamilyErrorCode.PHONE_DECRYPT_FAILED);

--- a/src/main/java/hotspot/admin/family/service/GetFamilyRequestListServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/GetFamilyRequestListServiceImpl.java
@@ -77,7 +77,7 @@ public class GetFamilyRequestListServiceImpl implements GetFamilyRequestListServ
                     row.familyId(),
                     row.requestSubId(),
                     row.requesterName(),
-                    decryptAndMask(row.requesterPhoneNumberEnc()),
+                    decryptAndMask(row.requesterPhoneNumberEnc(), row.requestSubId()),
                     row.relationDocumentUrl(),
                     row.requestedAt()
             ));
@@ -86,7 +86,7 @@ public class GetFamilyRequestListServiceImpl implements GetFamilyRequestListServ
                 acc.targets.add(FamilyRequestTargetItem.builder()
                         .targetSubId(row.targetSubId())
                         .targetName(row.targetName())
-                        .targetPhoneNumber(decryptAndMask(row.targetPhoneNumberEnc()))
+                        .targetPhoneNumber(decryptAndMask(row.targetPhoneNumberEnc(), row.targetSubId()))
                         .targetFamilyRole(row.targetFamilyRole())
                         .build());
             }
@@ -113,13 +113,13 @@ public class GetFamilyRequestListServiceImpl implements GetFamilyRequestListServ
     }
 
     /** 단일 전화번호를 복호화 후 마스킹 형식으로 변환한다. */
-    private String decryptAndMask(String phoneEnc) {
+    private String decryptAndMask(String phoneEnc, Long subId) {
         if (phoneEnc == null || phoneEnc.isBlank()) {
             return phoneEnc;
         }
 
         try {
-            String decrypted = phoneCryptoUtil.decryptPhone(phoneEnc);
+            String decrypted = phoneCryptoUtil.decryptPhone(phoneEnc, subId);
             return PhoneMaskingUtil.maskMiddle(decrypted);
         } catch (GeneralSecurityException e) {
             throw new ApplicationException(FamilyErrorCode.PHONE_DECRYPT_FAILED);

--- a/src/main/java/hotspot/admin/family/service/GetFamilySummaryServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/GetFamilySummaryServiceImpl.java
@@ -46,6 +46,7 @@ public class GetFamilySummaryServiceImpl implements GetFamilySummaryService {
         if (item.phoneNumber() == null || item.phoneNumber().isBlank()) {
             return FamilyListItem.builder()
                     .familyId(item.familyId())
+                    .subId(item.subId())
                     .displayId(DisplayIdFormatter.format(DisplayIdType.FAMILY, item.familyId()))
                     .representativeName(item.representativeName())
                     .phoneNumber(item.phoneNumber())
@@ -54,10 +55,11 @@ public class GetFamilySummaryServiceImpl implements GetFamilySummaryService {
         }
 
         try {
-            String decrypted = phoneCryptoUtil.decryptPhone(item.phoneNumber());
+            String decrypted = phoneCryptoUtil.decryptPhone(item.phoneNumber(), item.subId());
             String masked = PhoneMaskingUtil.maskMiddle(decrypted);
             return FamilyListItem.builder()
                     .familyId(item.familyId())
+                    .subId(item.subId())
                     .displayId(DisplayIdFormatter.format(DisplayIdType.FAMILY, item.familyId()))
                     .representativeName(item.representativeName())
                     .phoneNumber(masked)

--- a/src/main/java/hotspot/admin/family/service/SearchFamilyByPhoneServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/SearchFamilyByPhoneServiceImpl.java
@@ -63,6 +63,7 @@ public class SearchFamilyByPhoneServiceImpl implements SearchFamilyByPhoneServic
         if (item.phoneNumber() == null || item.phoneNumber().isBlank()) {
             return FamilyListItem.builder()
                     .familyId(item.familyId())
+                    .subId(item.subId())
                     .displayId(DisplayIdFormatter.format(DisplayIdType.FAMILY, item.familyId()))
                     .representativeName(item.representativeName())
                     .phoneNumber(item.phoneNumber())
@@ -71,10 +72,11 @@ public class SearchFamilyByPhoneServiceImpl implements SearchFamilyByPhoneServic
         }
 
         try {
-            String decrypted = phoneCryptoUtil.decryptPhone(item.phoneNumber());
+            String decrypted = phoneCryptoUtil.decryptPhone(item.phoneNumber(), item.subId());
             String masked = PhoneMaskingUtil.maskMiddle(decrypted);
             return FamilyListItem.builder()
                     .familyId(item.familyId())
+                    .subId(item.subId())
                     .displayId(DisplayIdFormatter.format(DisplayIdType.FAMILY, item.familyId()))
                     .representativeName(item.representativeName())
                     .phoneNumber(masked)

--- a/src/main/java/hotspot/admin/subscription/domain/Subscription.java
+++ b/src/main/java/hotspot/admin/subscription/domain/Subscription.java
@@ -17,6 +17,8 @@ public class Subscription {
     private final Member member;
     private final String phoneEnc;
     private final String phoneHash;
+    private final Integer phoneKeyBucketId;
+    private final Integer phoneKeyVersion;
     private final Boolean isLocked;
     private final Boolean isDeleted;
     private final LocalDateTime createdTime;

--- a/src/main/java/hotspot/admin/subscription/infrastructure/SubscriptionPhoneKeyLookupRepositoryImpl.java
+++ b/src/main/java/hotspot/admin/subscription/infrastructure/SubscriptionPhoneKeyLookupRepositoryImpl.java
@@ -1,0 +1,54 @@
+package hotspot.admin.subscription.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import hotspot.admin.subscription.service.port.SubscriptionPhoneKeyLookupRepository;
+import hotspot.admin.subscription.service.port.dto.SubscriptionPhoneKeyInfo;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriptionPhoneKeyLookupRepositoryImpl implements SubscriptionPhoneKeyLookupRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public Optional<SubscriptionPhoneKeyInfo> findPhoneKeyInfoBySubId(Long subId) {
+        String sql = """
+                SELECT
+                    s.sub_id,
+                    s.phone_key_bucket_id AS bucket_id,
+                    s.phone_key_version AS key_version,
+                    sk.encrypted_dek,
+                    sk.kek_key_id,
+                    sk.status
+                FROM subscription s
+                JOIN subscription_key sk
+                  ON sk.bucket_id = s.phone_key_bucket_id
+                 AND sk.key_version = s.phone_key_version
+                WHERE s.sub_id = :subId
+                  AND s.is_deleted = false
+                LIMIT 1
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("subId", subId);
+
+        List<SubscriptionPhoneKeyInfo> result = jdbcTemplate.query(sql, params, (rs, rowNum) ->
+                SubscriptionPhoneKeyInfo.builder()
+                        .subId(rs.getLong("sub_id"))
+                        .bucketId(rs.getInt("bucket_id"))
+                        .keyVersion(rs.getInt("key_version"))
+                        .encryptedDek(rs.getString("encrypted_dek"))
+                        .kekKeyId(rs.getString("kek_key_id"))
+                        .status(rs.getString("status"))
+                        .build());
+
+        return result.stream().findFirst();
+    }
+}

--- a/src/main/java/hotspot/admin/subscription/infrastructure/entity/SubscriptionEntity.java
+++ b/src/main/java/hotspot/admin/subscription/infrastructure/entity/SubscriptionEntity.java
@@ -52,6 +52,12 @@ public class SubscriptionEntity extends BaseEntity {
     @Column(name = "phone_hash", length = 64, nullable = false)
     private String phoneHash;
 
+    @Column(name = "phone_key_bucket_id", nullable = false)
+    private Integer phoneKeyBucketId;
+
+    @Column(name = "phone_key_version", nullable = false)
+    private Integer phoneKeyVersion;
+
     @Column(name = "is_locked", nullable = false)
     @Builder.Default
     private Boolean isLocked = false;
@@ -71,6 +77,8 @@ public class SubscriptionEntity extends BaseEntity {
                 .member(memberEntity)
                 .phoneEnc(subscription.getPhoneEnc())
                 .phoneHash(subscription.getPhoneHash())
+                .phoneKeyBucketId(subscription.getPhoneKeyBucketId())
+                .phoneKeyVersion(subscription.getPhoneKeyVersion())
                 .isLocked(subscription.getIsLocked())
                 .isDeleted(subscription.getIsDeleted())
                 .build();
@@ -83,6 +91,8 @@ public class SubscriptionEntity extends BaseEntity {
                 .member(member.entityToDomain())
                 .phoneEnc(phoneEnc)
                 .phoneHash(phoneHash)
+                .phoneKeyBucketId(phoneKeyBucketId)
+                .phoneKeyVersion(phoneKeyVersion)
                 .isLocked(isLocked)
                 .isDeleted(isDeleted)
                 .createdTime(getCreatedTime())

--- a/src/main/java/hotspot/admin/subscription/service/port/SubscriptionPhoneKeyLookupRepository.java
+++ b/src/main/java/hotspot/admin/subscription/service/port/SubscriptionPhoneKeyLookupRepository.java
@@ -1,0 +1,9 @@
+package hotspot.admin.subscription.service.port;
+
+import java.util.Optional;
+
+import hotspot.admin.subscription.service.port.dto.SubscriptionPhoneKeyInfo;
+
+public interface SubscriptionPhoneKeyLookupRepository {
+    Optional<SubscriptionPhoneKeyInfo> findPhoneKeyInfoBySubId(Long subId);
+}

--- a/src/main/java/hotspot/admin/subscription/service/port/dto/SubscriptionPhoneKeyInfo.java
+++ b/src/main/java/hotspot/admin/subscription/service/port/dto/SubscriptionPhoneKeyInfo.java
@@ -1,0 +1,14 @@
+package hotspot.admin.subscription.service.port.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SubscriptionPhoneKeyInfo(
+        Long subId,
+        Integer bucketId,
+        Integer keyVersion,
+        String encryptedDek,
+        String kekKeyId,
+        String status
+) {
+}

--- a/src/main/java/hotspot/admin/usage/subscriptionUsage/service/FindSubscriptionUsageServiceImpl.java
+++ b/src/main/java/hotspot/admin/usage/subscriptionUsage/service/FindSubscriptionUsageServiceImpl.java
@@ -84,7 +84,7 @@ public class FindSubscriptionUsageServiceImpl implements FindSubscriptionUsageSe
                     SubscriptionUsage usage =
                             usageMap.get(subId);
 
-                    String maskedPhone = decryptAndMaskPhone(subscription.getPhoneEnc());
+                    String maskedPhone = decryptAndMaskPhone(subscription.getPhoneEnc(), subId);
                     Boolean blocked = blockedBySubId.getOrDefault(
                             subId,
                             Boolean.TRUE.equals(subscription.getIsLocked())
@@ -104,13 +104,13 @@ public class FindSubscriptionUsageServiceImpl implements FindSubscriptionUsageSe
                 .toList();
     }
 
-    private String decryptAndMaskPhone(String encryptedPhone) {
+    private String decryptAndMaskPhone(String encryptedPhone, Long subId) {
         if (encryptedPhone == null || encryptedPhone.isBlank()) {
             return encryptedPhone;
         }
 
         try {
-            String decrypted = phoneCryptoUtil.decryptPhone(encryptedPhone);
+            String decrypted = phoneCryptoUtil.decryptPhone(encryptedPhone, subId);
             return PhoneMaskingUtil.maskMiddle(decrypted);
         } catch (GeneralSecurityException e) {
             throw new ApplicationException(FamilyErrorCode.PHONE_DECRYPT_FAILED);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,8 @@ project:
   name: Hotspot Admin Domain API
   version: 1.0.0
   admin-code: ${ADMIN_CODE}
+  encryption-provider: ${ENCRYPTION_PROVIDER:local}
+  kms-key-id: ${KEK_KEY_ID:}
   phone-secret-key: ${PHONE_SECRET_KEY}
   phone-hash-key: ${PHONE_HASH_KEY}
 

--- a/src/test/java/hotspot/admin/family/service/GetFamilyListServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/GetFamilyListServiceTest.java
@@ -2,6 +2,7 @@ package hotspot.admin.family.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -49,12 +50,14 @@ class GetFamilyListServiceTest {
         List<FamilyListItem> rows = List.of(
                 FamilyListItem.builder()
                         .familyId(1L)
+                        .subId(101L)
                         .representativeName("대표자1")
                         .phoneNumber("enc-1")
                         .memberCount(2)
                         .build(),
                 FamilyListItem.builder()
                         .familyId(2L)
+                        .subId(102L)
                         .representativeName("대표자2")
                         .phoneNumber("enc-2")
                         .memberCount(3)
@@ -65,7 +68,7 @@ class GetFamilyListServiceTest {
                 .thenReturn(25L);
         when(familyQueryRepository.findFamilyList(20, 0))
                 .thenReturn(rows);
-        when(phoneCryptoUtil.decryptPhone(anyString()))
+        when(phoneCryptoUtil.decryptPhone(anyString(), anyLong()))
                 .thenReturn("01012340000");
 
         FamilyListResponse response = service.getFamilyList(request);
@@ -88,6 +91,7 @@ class GetFamilyListServiceTest {
 
         List<FamilyListItem> rows = List.of(FamilyListItem.builder()
                 .familyId(1L)
+                .subId(101L)
                 .representativeName("대표자")
                 .phoneNumber("enc")
                 .memberCount(2)
@@ -97,7 +101,7 @@ class GetFamilyListServiceTest {
                 .thenReturn(1L);
         when(familyQueryRepository.findFamilyList(20, 0))
                 .thenReturn(rows);
-        when(phoneCryptoUtil.decryptPhone("enc"))
+        when(phoneCryptoUtil.decryptPhone("enc", 101L))
                 .thenThrow(new GeneralSecurityException("decrypt failed"));
 
         assertThatThrownBy(() -> service.getFamilyList(request))

--- a/src/test/java/hotspot/admin/family/service/GetFamilyPolicyDetailStatusServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/GetFamilyPolicyDetailStatusServiceTest.java
@@ -119,7 +119,7 @@ class GetFamilyPolicyDetailStatusServiceTest {
                 ));
         when(familyBlockedStatusResolver.resolveBlockedBySubId(1L))
                 .thenReturn(java.util.Map.of(10L, true, 11L, false));
-        when(phoneCryptoUtil.decryptPhone("enc-1")).thenReturn("01011112222");
+        when(phoneCryptoUtil.decryptPhone("enc-1", 10L)).thenReturn("01011112222");
 
         FamilyPolicyMemberDetailItem response = service.getFamilyPolicyDetailStatus(1L, 10L);
 
@@ -200,7 +200,7 @@ class GetFamilyPolicyDetailStatusServiceTest {
         when(familySubQueryRepository.findFamilyAppPolicies(1L)).thenReturn(List.of());
         when(familyBlockedStatusResolver.resolveBlockedBySubId(1L))
                 .thenReturn(java.util.Map.of(1L, false));
-        when(phoneCryptoUtil.decryptPhone("enc")).thenThrow(new GeneralSecurityException("decrypt failed"));
+        when(phoneCryptoUtil.decryptPhone("enc", 1L)).thenThrow(new GeneralSecurityException("decrypt failed"));
 
         assertThatThrownBy(() -> service.getFamilyPolicyDetailStatus(1L, 1L))
                 .isInstanceOf(ApplicationException.class)

--- a/src/test/java/hotspot/admin/family/service/GetFamilyPolicyStatusServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/GetFamilyPolicyStatusServiceTest.java
@@ -75,8 +75,8 @@ class GetFamilyPolicyStatusServiceTest {
                                 .appliedBlockedServicePolicies(List.of())
                                 .build()
                 ));
-        when(phoneCryptoUtil.decryptPhone("enc-1")).thenReturn("01011112222");
-        when(phoneCryptoUtil.decryptPhone("enc-2")).thenReturn("01033334444");
+        when(phoneCryptoUtil.decryptPhone("enc-1", 10L)).thenReturn("01011112222");
+        when(phoneCryptoUtil.decryptPhone("enc-2", 11L)).thenReturn("01033334444");
         when(familyBlockedStatusResolver.resolveBlockedBySubId(1L))
                 .thenReturn(java.util.Map.of(10L, true, 11L, true));
 
@@ -119,7 +119,7 @@ class GetFamilyPolicyStatusServiceTest {
                         .build()));
         when(familyBlockedStatusResolver.resolveBlockedBySubId(1L))
                 .thenReturn(java.util.Map.of(1L, false));
-        when(phoneCryptoUtil.decryptPhone("enc")).thenThrow(new GeneralSecurityException("decrypt failed"));
+        when(phoneCryptoUtil.decryptPhone("enc", 1L)).thenThrow(new GeneralSecurityException("decrypt failed"));
 
         assertThatThrownBy(() -> service.getFamilyPolicyStatus(1L))
                 .isInstanceOf(ApplicationException.class)

--- a/src/test/java/hotspot/admin/family/service/GetFamilyRequestListServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/GetFamilyRequestListServiceTest.java
@@ -69,9 +69,9 @@ class GetFamilyRequestListServiceTest {
                 .thenReturn(1L);
         when(familyApplyQueryRepository.findFamilyRequestList(ApplyType.ADD, FamilyApplyStatus.PENDING, 20, 0))
                 .thenReturn(List.of(row));
-        when(phoneCryptoUtil.decryptPhone("enc-requester"))
+        when(phoneCryptoUtil.decryptPhone("enc-requester", 100L))
                 .thenReturn("01011112222");
-        when(phoneCryptoUtil.decryptPhone("enc-target"))
+        when(phoneCryptoUtil.decryptPhone("enc-target", 101L))
                 .thenReturn("01033334444");
 
         FamilyRequestListResponse result = service.getFamilyRequests(ApplyType.ADD, FamilyApplyStatus.PENDING, request);
@@ -118,7 +118,7 @@ class GetFamilyRequestListServiceTest {
                 .thenReturn(1L);
         when(familyApplyQueryRepository.findFamilyRequestList(ApplyType.REMOVE, FamilyApplyStatus.APPROVED, 20, 0))
                 .thenReturn(List.of(row));
-        when(phoneCryptoUtil.decryptPhone("enc-requester"))
+        when(phoneCryptoUtil.decryptPhone("enc-requester", 10L))
                 .thenThrow(new GeneralSecurityException("decrypt failed"));
 
         assertThatThrownBy(() -> service.getFamilyRequests(ApplyType.REMOVE, FamilyApplyStatus.APPROVED, request))

--- a/src/test/java/hotspot/admin/family/service/GetFamilySummaryServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/GetFamilySummaryServiceTest.java
@@ -42,6 +42,7 @@ class GetFamilySummaryServiceTest {
     void getFamilySummarySuccess() throws Exception {
         FamilyListItem row = FamilyListItem.builder()
                 .familyId(3L)
+                .subId(103L)
                 .representativeName("대표자")
                 .phoneNumber("enc-phone")
                 .memberCount(4)
@@ -49,7 +50,7 @@ class GetFamilySummaryServiceTest {
 
         when(familyQueryRepository.findFamilyById(3L))
                 .thenReturn(Optional.of(row));
-        when(phoneCryptoUtil.decryptPhone("enc-phone"))
+        when(phoneCryptoUtil.decryptPhone("enc-phone", 103L))
                 .thenReturn("01012345678");
 
         FamilySummaryResponse response = service.getFamilySummary(3L);
@@ -77,6 +78,7 @@ class GetFamilySummaryServiceTest {
     void decryptFailThenException() throws Exception {
         FamilyListItem row = FamilyListItem.builder()
                 .familyId(8L)
+                .subId(108L)
                 .representativeName("대표자")
                 .phoneNumber("enc")
                 .memberCount(2)
@@ -84,7 +86,7 @@ class GetFamilySummaryServiceTest {
 
         when(familyQueryRepository.findFamilyById(8L))
                 .thenReturn(Optional.of(row));
-        when(phoneCryptoUtil.decryptPhone("enc"))
+        when(phoneCryptoUtil.decryptPhone("enc", 108L))
                 .thenThrow(new GeneralSecurityException("decrypt failed"));
 
         assertThatThrownBy(() -> service.getFamilySummary(8L))

--- a/src/test/java/hotspot/admin/family/service/SearchFamilyByPhoneServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/SearchFamilyByPhoneServiceTest.java
@@ -49,11 +49,12 @@ class SearchFamilyByPhoneServiceTest {
         when(familyQueryRepository.findFamilyByPhoneHash("hashed-phone"))
                 .thenReturn(Optional.of(FamilyListItem.builder()
                         .familyId(10L)
+                        .subId(110L)
                         .representativeName("대표자")
                         .phoneNumber("encrypted-phone")
                         .memberCount(3)
                         .build()));
-        when(phoneCryptoUtil.decryptPhone("encrypted-phone"))
+        when(phoneCryptoUtil.decryptPhone("encrypted-phone", 110L))
                 .thenReturn("01012345678");
 
         FamilyListResponse response = service.searchByPhone("010-1234-5678");

--- a/src/test/java/hotspot/admin/subscription/infrastructure/SubscriptionPhoneKeyLookupRepositoryImplTest.java
+++ b/src/test/java/hotspot/admin/subscription/infrastructure/SubscriptionPhoneKeyLookupRepositoryImplTest.java
@@ -1,0 +1,71 @@
+package hotspot.admin.subscription.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import hotspot.admin.subscription.service.port.dto.SubscriptionPhoneKeyInfo;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionPhoneKeyLookupRepositoryImplTest {
+
+    @Mock
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("subId로 전화번호 키 정보를 조회한다")
+    void findPhoneKeyInfoBySubId() throws Exception {
+        SubscriptionPhoneKeyLookupRepositoryImpl repository =
+                new SubscriptionPhoneKeyLookupRepositoryImpl(jdbcTemplate);
+
+        when(jdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    RowMapper<SubscriptionPhoneKeyInfo> mapper = invocation.getArgument(2);
+
+                    ResultSet rs = org.mockito.Mockito.mock(ResultSet.class);
+                    when(rs.getLong("sub_id")).thenReturn(101L);
+                    when(rs.getInt("bucket_id")).thenReturn(101);
+                    when(rs.getInt("key_version")).thenReturn(3);
+                    when(rs.getString("encrypted_dek")).thenReturn("wrapped-dek");
+                    when(rs.getString("kek_key_id")).thenReturn("kek-arn");
+                    when(rs.getString("status")).thenReturn("active");
+
+                    return List.of(mapper.mapRow(rs, 0));
+                });
+
+        SubscriptionPhoneKeyInfo result = repository.findPhoneKeyInfoBySubId(101L).orElseThrow();
+
+        assertThat(result.subId()).isEqualTo(101L);
+        assertThat(result.bucketId()).isEqualTo(101);
+        assertThat(result.keyVersion()).isEqualTo(3);
+        assertThat(result.encryptedDek()).isEqualTo("wrapped-dek");
+        assertThat(result.kekKeyId()).isEqualTo("kek-arn");
+        assertThat(result.status()).isEqualTo("active");
+    }
+
+    @Test
+    @DisplayName("조회 결과가 없으면 empty를 반환한다")
+    void findPhoneKeyInfoBySubIdEmpty() {
+        SubscriptionPhoneKeyLookupRepositoryImpl repository =
+                new SubscriptionPhoneKeyLookupRepositoryImpl(jdbcTemplate);
+
+        when(jdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+                .thenReturn(List.of());
+
+        assertThat(repository.findPhoneKeyInfoBySubId(999L)).isEmpty();
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-294

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #71 
-->
Closes #71

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
ADMIN-BE의 전화번호 복호화 경로를 기존 단일 SECRET_KEY 직접 복호화  방식에서 subscription_key 기반 DEK 복호화 방식으로 전환했습니다.  .generator-dummy의 최신 암호화 규칙과 맞춰 subId를 기준으로 키를 조회하고, ENCRYPTION_PROVIDER=local/kms에 따라 DEK를 복원한 뒤 전화번호를 복호화하도록 변경했습니다. 기존 전화번호 마스킹 로직은 그대로 유지합니다.

- Subscription / SubscriptionEntity에 phone_key_bucket_id,
    phone_key_version 매핑 추가
  - subscription + subscription_key 조인으로 encrypted_dek,
    kek_key_id를 조회하는 키 조회 컴포넌트 추가
  - PhoneCryptoUtil.decryptPhone(encryptedPhone, subId)로 복호화 시
    그니처 변경
  - ENCRYPTION_PROVIDER에 따라 local 언래핑 또는 AWS KMS Decrypt 수
    행
  - 전화번호 복호화 포맷을 gcm: prefix 우선, legacy CBC fallback으로
    통일
  - 가족 목록/요약/검색/정책/요청/사용량 조회의 모든 복호화 호출을
    subId 기반으로 전환
  - 가족 대표 전화번호를 조회하는 JDBC/native SQL에 대응 subId도 함
    께 조회하도록 수정
  - 관련 단위 테스트와 신규 키 조회 repository 테스트 추가

  설정 변경

  - build.gradle
      - software.amazon.awssdk:kms 의존성 추가
  - application.yml
      - project.encryption-provider: ${ENCRYPTION_PROVIDER:local}
      - project.kms-key-id: ${KEK_KEY_ID:}
      - 기존 project.phone-secret-key는 local fallback 언래핑 용도로
        유지

  검증 포인트

  - ENCRYPTION_PROVIDER=local에서 전화번호 정상 복호화 및 마스킹
  - ENCRYPTION_PROVIDER=kms에서 AWS 자격증명/KEK 설정 후 정상 복호화
  - 기존 CBC 암호문에 대한 fallback 복호화
  - 가족 목록/요약/요청/정책/사용량 화면에서 마스킹 값 정상 노출
  - 빌드 및 테스트 통과

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
