### PR TITLE
[HOTSPOT-319] 관리자가 정책 변경 시 알림 OutBox 패턴 구현

### DIFF
--- a/src/main/java/hotspot/admin/family/outbox/FamilyPolicyOutboxPublisher.java
+++ b/src/main/java/hotspot/admin/family/outbox/FamilyPolicyOutboxPublisher.java
@@ -1,0 +1,79 @@
+package hotspot.admin.family.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import hotspot.admin.common.exception.ApplicationException;
+import hotspot.admin.common.exception.code.OutboxErrorCode;
+import hotspot.admin.family.controller.request.PolicyActiveRequest;
+import hotspot.admin.family.outbox.dto.FamilyPolicyAlertEvent;
+import hotspot.admin.outbox.notificationOutbox.service.NotificationOutboxEventAppender;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FamilyPolicyOutboxPublisher {
+
+    private static final String AGGREGATE_TYPE = "user-alert";
+    private static final String EVENT_TYPE_TIME_WINDOW_POLICY = "TIME_WINDOW_POLICY";
+    private static final String EVENT_TYPE_IMMEDIATE_BLOCK = "IMMEDIATE_BLOCK";
+    private static final String EVENT_TYPE_SERVICE_ACCESS = "SERVICE_ACCESS";
+    private static final String ALERT_TYPE_APPLIED = "APPLIED";
+    private static final String ALERT_TYPE_RELEASED = "RELEASED";
+
+    private final NotificationOutboxEventAppender outboxEventAppender;
+
+    public void publishTimeWindowPolicy(Long familyId, Long subId, List<PolicyActiveRequest> policies) {
+        publish(resolvePolicyAlertType(policies), EVENT_TYPE_TIME_WINDOW_POLICY, familyId, subId);
+    }
+
+    public void publishServiceAccess(Long familyId, Long subId, List<PolicyActiveRequest> policies) {
+        publish(resolvePolicyAlertType(policies), EVENT_TYPE_SERVICE_ACCESS, familyId, subId);
+    }
+
+    public void publishImmediateBlock(Long familyId, Long subId, boolean isBlocked) {
+        publish(isBlocked ? ALERT_TYPE_APPLIED : ALERT_TYPE_RELEASED, EVENT_TYPE_IMMEDIATE_BLOCK, familyId, subId);
+    }
+
+    private void publish(String alertType, String eventType, Long familyId, Long subId) {
+        try {
+            String aggregateId = familyId != null ? String.valueOf(familyId) : String.valueOf(subId);
+
+            FamilyPolicyAlertEvent event = new FamilyPolicyAlertEvent(
+                    UUID.randomUUID().toString(),
+                    eventType,
+                    alertType,
+                    subId,
+                    familyId,
+                    LocalDateTime.now()
+            );
+
+            outboxEventAppender.append(
+                    AGGREGATE_TYPE,
+                    aggregateId,
+                    eventType,
+                    event
+            );
+        } catch (ApplicationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new ApplicationException(OutboxErrorCode.OUTBOX_EVENT_PUBLISH_FAILED, ex);
+        }
+    }
+
+    private String resolvePolicyAlertType(List<PolicyActiveRequest> policies) {
+        boolean hasApplied = policies.stream().anyMatch(PolicyActiveRequest::isActive);
+        boolean hasReleased = policies.stream().anyMatch(policy -> !policy.isActive());
+
+        if (hasApplied && hasReleased) {
+            return ALERT_TYPE_APPLIED;
+        }
+        if (hasApplied) {
+            return ALERT_TYPE_APPLIED;
+        }
+        return ALERT_TYPE_RELEASED;
+    }
+}

--- a/src/main/java/hotspot/admin/family/outbox/FamilyPolicyOutboxPublisher.java
+++ b/src/main/java/hotspot/admin/family/outbox/FamilyPolicyOutboxPublisher.java
@@ -65,15 +65,8 @@ public class FamilyPolicyOutboxPublisher {
     }
 
     private String resolvePolicyAlertType(List<PolicyActiveRequest> policies) {
-        boolean hasApplied = policies.stream().anyMatch(PolicyActiveRequest::isActive);
-        boolean hasReleased = policies.stream().anyMatch(policy -> !policy.isActive());
-
-        if (hasApplied && hasReleased) {
-            return ALERT_TYPE_APPLIED;
-        }
-        if (hasApplied) {
-            return ALERT_TYPE_APPLIED;
-        }
-        return ALERT_TYPE_RELEASED;
+        return policies.stream().anyMatch(PolicyActiveRequest::isActive)
+                ? ALERT_TYPE_APPLIED
+                : ALERT_TYPE_RELEASED;
     }
 }

--- a/src/main/java/hotspot/admin/family/outbox/dto/FamilyPolicyAlertEvent.java
+++ b/src/main/java/hotspot/admin/family/outbox/dto/FamilyPolicyAlertEvent.java
@@ -1,0 +1,13 @@
+package hotspot.admin.family.outbox.dto;
+
+import java.time.LocalDateTime;
+
+public record FamilyPolicyAlertEvent(
+        String alertId,
+        String eventType,
+        String alertType,
+        Long subId,
+        Long familyId,
+        LocalDateTime createdTime
+) {
+}

--- a/src/main/java/hotspot/admin/family/service/UpdateFamilyMemberControlStatusServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/UpdateFamilyMemberControlStatusServiceImpl.java
@@ -10,6 +10,7 @@ import hotspot.admin.common.exception.ApplicationException;
 import hotspot.admin.common.exception.code.FamilyErrorCode;
 import hotspot.admin.family.controller.port.UpdateFamilyMemberControlStatusService;
 import hotspot.admin.family.domain.FamilyRole;
+import hotspot.admin.family.outbox.FamilyPolicyOutboxPublisher;
 import hotspot.admin.family.service.port.FamilyRepository;
 import hotspot.admin.family.service.port.FamilySubRepository;
 import hotspot.admin.outbox.consistencyOutbox.domain.event.family.limit.FamilySubLimitChangedEvent;
@@ -29,6 +30,7 @@ public class UpdateFamilyMemberControlStatusServiceImpl implements UpdateFamilyM
     private final SubscriptionJpaRepository subscriptionJpaRepository;
 
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final FamilyPolicyOutboxPublisher familyPolicyOutboxPublisher;
 
     @Transactional
     @Override
@@ -72,6 +74,7 @@ public class UpdateFamilyMemberControlStatusServiceImpl implements UpdateFamilyM
             }
 
             publishSubscriptionStatusEvent(subId, isBlocked, current);
+            familyPolicyOutboxPublisher.publishImmediateBlock(familyId, subId, isBlocked);
         }
 
         if (isParent != null) {

--- a/src/main/java/hotspot/admin/family/service/UpdateFamilyMemberPolicyStatusServiceImpl.java
+++ b/src/main/java/hotspot/admin/family/service/UpdateFamilyMemberPolicyStatusServiceImpl.java
@@ -15,6 +15,7 @@ import hotspot.admin.common.exception.code.FamilyErrorCode;
 import hotspot.admin.common.exception.code.PolicyErrorCode;
 import hotspot.admin.family.controller.port.UpdateFamilyMemberPolicyStatusService;
 import hotspot.admin.family.controller.request.PolicyActiveRequest;
+import hotspot.admin.family.outbox.FamilyPolicyOutboxPublisher;
 import hotspot.admin.family.service.port.FamilyPolicyAssignmentRepository;
 import hotspot.admin.family.service.port.FamilyRepository;
 import hotspot.admin.family.service.port.FamilySubRepository;
@@ -31,6 +32,7 @@ public class UpdateFamilyMemberPolicyStatusServiceImpl implements UpdateFamilyMe
     private final FamilyPolicyAssignmentRepository familyPolicyAssignmentRepository;
     private final PolicyBlockSnapshotPublisher policyBlockSnapshotPublisher;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final FamilyPolicyOutboxPublisher familyPolicyOutboxPublisher;
 
     @Transactional
     @Override
@@ -42,6 +44,7 @@ public class UpdateFamilyMemberPolicyStatusServiceImpl implements UpdateFamilyMe
         validateFamilyAndMember(familyId, subId);
         validateTimePolicies(familyId, policies);
         updateTimePolicies(subId, policies);
+        familyPolicyOutboxPublisher.publishTimeWindowPolicy(familyId, subId, policies);
     }
 
     @Transactional
@@ -54,6 +57,7 @@ public class UpdateFamilyMemberPolicyStatusServiceImpl implements UpdateFamilyMe
         validateFamilyAndMember(familyId, subId);
         validateAppPolicies(policies);
         updateAppPolicies(subId, policies);
+        familyPolicyOutboxPublisher.publishServiceAccess(familyId, subId, policies);
     }
 
     private void validateTimePolicies(Long familyId, List<PolicyActiveRequest> policies) {

--- a/src/test/java/hotspot/admin/family/outbox/FamilyPolicyOutboxPublisherTest.java
+++ b/src/test/java/hotspot/admin/family/outbox/FamilyPolicyOutboxPublisherTest.java
@@ -1,0 +1,92 @@
+package hotspot.admin.family.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.admin.common.exception.ApplicationException;
+import hotspot.admin.common.exception.code.OutboxErrorCode;
+import hotspot.admin.family.controller.request.PolicyActiveRequest;
+import hotspot.admin.family.outbox.dto.FamilyPolicyAlertEvent;
+import hotspot.admin.outbox.notificationOutbox.service.NotificationOutboxEventAppender;
+
+@ExtendWith(MockitoExtension.class)
+class FamilyPolicyOutboxPublisherTest {
+
+    @Mock
+    private NotificationOutboxEventAppender outboxEventAppender;
+
+    private FamilyPolicyOutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new FamilyPolicyOutboxPublisher(outboxEventAppender);
+    }
+
+    @Test
+    @DisplayName("time policy 적용/해제 이벤트 outbox 저장")
+    void publishTimeWindowPolicy() {
+        List<PolicyActiveRequest> policies = List.of(
+                new PolicyActiveRequest(101L, true),
+                new PolicyActiveRequest(102L, false)
+        );
+
+        publisher.publishTimeWindowPolicy(1L, 10L, policies);
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(outboxEventAppender).append(
+                eq("user-alert"),
+                eq("1"),
+                eq("TIME_WINDOW_POLICY"),
+                payloadCaptor.capture()
+        );
+
+        FamilyPolicyAlertEvent event = (FamilyPolicyAlertEvent) payloadCaptor.getValue();
+        assertThat(event.alertId()).isNotBlank();
+        assertThat(event.eventType()).isEqualTo("TIME_WINDOW_POLICY");
+        assertThat(event.alertType()).isEqualTo("APPLIED");
+        assertThat(event.subId()).isEqualTo(10L);
+        assertThat(event.familyId()).isEqualTo(1L);
+        assertThat(event.createdTime()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("즉시차단 해제 이벤트 outbox 저장")
+    void publishImmediateBlockReleased() {
+        publisher.publishImmediateBlock(1L, 10L, false);
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(outboxEventAppender).append(
+                eq("user-alert"),
+                eq("1"),
+                eq("IMMEDIATE_BLOCK"),
+                payloadCaptor.capture()
+        );
+
+        FamilyPolicyAlertEvent event = (FamilyPolicyAlertEvent) payloadCaptor.getValue();
+        assertThat(event.alertType()).isEqualTo("RELEASED");
+    }
+
+    @Test
+    @DisplayName("outbox 저장 예외는 publish 예외로 변환")
+    void publishWrapUnexpectedException() {
+        doThrow(new RuntimeException("boom")).when(outboxEventAppender).append(any(), any(), any(), any());
+
+        assertThatThrownBy(() -> publisher.publishServiceAccess(1L, 10L, List.of(new PolicyActiveRequest(201L, true))))
+                .isInstanceOf(ApplicationException.class)
+                .matches(ex -> ((ApplicationException) ex).getCode() == OutboxErrorCode.OUTBOX_EVENT_PUBLISH_FAILED);
+    }
+}

--- a/src/test/java/hotspot/admin/family/service/UpdateFamilyMemberControlStatusServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/UpdateFamilyMemberControlStatusServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import hotspot.admin.common.exception.ApplicationException;
 import hotspot.admin.common.exception.code.FamilyErrorCode;
 import hotspot.admin.family.domain.FamilyRole;
+import hotspot.admin.family.outbox.FamilyPolicyOutboxPublisher;
 import hotspot.admin.family.service.port.FamilyRepository;
 import hotspot.admin.family.service.port.FamilySubRepository;
 import hotspot.admin.subscription.infrastructure.SubscriptionJpaRepository;
@@ -34,6 +35,9 @@ class UpdateFamilyMemberControlStatusServiceTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
+    @Mock
+    private FamilyPolicyOutboxPublisher familyPolicyOutboxPublisher;
+
     private UpdateFamilyMemberControlStatusServiceImpl service;
 
     @BeforeEach
@@ -42,7 +46,8 @@ class UpdateFamilyMemberControlStatusServiceTest {
                 familyRepository,
                 familySubRepository,
                 subscriptionJpaRepository,
-                applicationEventPublisher
+                applicationEventPublisher,
+                familyPolicyOutboxPublisher
         );
     }
 
@@ -61,6 +66,7 @@ class UpdateFamilyMemberControlStatusServiceTest {
 
         verify(familySubRepository).updateMemberDataLimit(1L, 101L, 1048576L);
         verify(familySubRepository).updateMemberBlocked(1L, 101L, true);
+        verify(familyPolicyOutboxPublisher).publishImmediateBlock(1L, 101L, true);
     }
 
     @Test

--- a/src/test/java/hotspot/admin/family/service/UpdateFamilyMemberPolicyStatusServiceTest.java
+++ b/src/test/java/hotspot/admin/family/service/UpdateFamilyMemberPolicyStatusServiceTest.java
@@ -20,6 +20,7 @@ import hotspot.admin.common.exception.ApplicationException;
 import hotspot.admin.common.exception.code.FamilyErrorCode;
 import hotspot.admin.common.exception.code.PolicyErrorCode;
 import hotspot.admin.family.controller.request.PolicyActiveRequest;
+import hotspot.admin.family.outbox.FamilyPolicyOutboxPublisher;
 import hotspot.admin.family.service.port.FamilyPolicyAssignmentRepository;
 import hotspot.admin.family.service.port.FamilyRepository;
 import hotspot.admin.family.service.port.FamilySubRepository;
@@ -44,6 +45,9 @@ class UpdateFamilyMemberPolicyStatusServiceTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
+    @Mock
+    private FamilyPolicyOutboxPublisher familyPolicyOutboxPublisher;
+
     private UpdateFamilyMemberPolicyStatusServiceImpl service;
 
     @BeforeEach
@@ -53,7 +57,8 @@ class UpdateFamilyMemberPolicyStatusServiceTest {
                 familySubRepository,
                 familyPolicyAssignmentRepository,
                 policyBlockSnapshotPublisher,
-                applicationEventPublisher
+                applicationEventPublisher,
+                familyPolicyOutboxPublisher
         );
     }
 
@@ -85,6 +90,9 @@ class UpdateFamilyMemberPolicyStatusServiceTest {
 
         verify(policyBlockSnapshotPublisher)
                 .publish(10L, List.of(101L));
+
+        verify(familyPolicyOutboxPublisher)
+                .publishTimeWindowPolicy(1L, 10L, policies);
     }
 
     @Test
@@ -115,6 +123,9 @@ class UpdateFamilyMemberPolicyStatusServiceTest {
 
         verify(applicationEventPublisher)
                 .publishEvent(org.mockito.ArgumentMatchers.any(AppBlockListUpdateEvent.class));
+
+        verify(familyPolicyOutboxPublisher)
+                .publishServiceAccess(1L, 10L, policies);
     }
 
     @Test


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-319

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #75 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 가족 정책 알림 OutBox DTO 추가
- 가족 구성원 정책 적용/해제 시 정책 알림 OutBox 발행 연동
- 즉시차단/해제 처리 시 정책 알림 OutBox 발행 추가
- 가족 정책 알림 발행 전용 퍼블리셔 추가

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
